### PR TITLE
Handle existing react-native fields

### DIFF
--- a/__fixtures__/invalid-fields/package.json
+++ b/__fixtures__/invalid-fields/package.json
@@ -4,5 +4,6 @@
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,
-  "module": "dist/index.mjs"
+  "module": "dist/index.mjs",
+  "react-native": "dist/index.native.js"
 }

--- a/__fixtures__/with-react-native-field/package.json
+++ b/__fixtures__/with-react-native-field/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "with-react-native-field",
+  "version": "1.0.0",
+  "main": "dist/with-react-native-field.cjs.js",
+  "module": "dist/with-react-native-field.esm.js",
+  "react-native": {
+    "./dist/with-react-native-field.cjs.js": "./dist/with-react-native-field.native.cjs.js",
+    "./dist/with-react-native-field.esm.js": "./dist/with-react-native-field.native.esm.js"
+  },
+  "license": "MIT",
+  "private": true
+}

--- a/__fixtures__/with-react-native-field/src/index.js
+++ b/__fixtures__/with-react-native-field/src/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export default "react native";

--- a/src/__tests__/fix.js
+++ b/src/__tests__/fix.js
@@ -123,6 +123,10 @@ Object {
   "module": "dist/invalid-fields.esm.js",
   "name": "invalid-fields",
   "private": true,
+  "react-native": Object {
+    "./dist/invalid-fields.cjs.js": "./dist/invalid-fields.native.cjs.js",
+    "./dist/invalid-fields.esm.js": "./dist/invalid-fields.native.esm.js",
+  },
   "version": "1.0.0",
 }
 `);

--- a/src/__tests__/init.js
+++ b/src/__tests__/init.js
@@ -196,6 +196,7 @@ Object {
   "module": "dist/invalid-fields.esm.js",
   "name": "invalid-fields",
   "private": true,
+  "react-native": "dist/index.native.js",
   "version": "1.0.0",
 }
 `);

--- a/src/__tests__/validate.js
+++ b/src/__tests__/validate.js
@@ -124,3 +124,33 @@ Array [
 ]
 `);
 });
+
+test("valid react-native", async () => {
+  let tmpPath = f.copy("with-react-native-field");
+
+  await validate(tmpPath);
+  expect(logMock.log.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "🎁 info with-react-native-field",
+    "a valid entry point exists.",
+  ],
+  Array [
+    "🎁 info with-react-native-field",
+    "main field is valid",
+  ],
+  Array [
+    "🎁 info with-react-native-field",
+    "module field is valid",
+  ],
+  Array [
+    "🎁 info with-react-native-field",
+    "react-native field is valid",
+  ],
+  Array [
+    "🎁 success",
+    "package is valid!",
+  ],
+]
+`);
+});

--- a/src/build/config.js
+++ b/src/build/config.js
@@ -5,7 +5,12 @@ import { type RollupConfig, getRollupConfig } from "./rollup";
 import type { OutputOptions } from "./types";
 import type { Aliases } from "./aliases";
 import is from "sarcastic";
-import { getValidCjsBrowserPath, getValidModuleBrowserPath } from "../utils";
+import {
+  getValidCjsBrowserPath,
+  getValidModuleBrowserPath,
+  getValidCjsReactNativePath,
+  getValidModuleReactNativePath
+} from "../utils";
 import { getDevPath, getProdPath } from "./utils";
 
 export function getRollupConfigs(pkg: StrictPackage, aliases: Aliases) {
@@ -77,6 +82,23 @@ export function getRollupConfigs(pkg: StrictPackage, aliases: Aliases) {
         {
           format: "es",
           file: path.join(pkg.directory, getValidModuleBrowserPath(pkg))
+        }
+      ]
+    });
+  }
+
+  if (pkg.reactNative !== null) {
+    configs.push({
+      config: getRollupConfig(pkg, aliases, "react-native"),
+      outputs: [
+        {
+          format: "cjs",
+          file: path.join(pkg.directory, getValidCjsReactNativePath(pkg)),
+          exports: "named"
+        },
+        {
+          format: "es",
+          file: path.join(pkg.directory, getValidModuleReactNativePath(pkg))
         }
       ]
     });

--- a/src/build/rollup.js
+++ b/src/build/rollup.js
@@ -49,33 +49,20 @@ function getChildPeerDeps(
       try {
         pkgJson = unsafeRequire(key + "/package.json");
       } catch (err) {
-        if (
-          err.code === "MODULE_NOT_FOUND" &&
-          pkgJsonsAllowedToFail.includes(key)
-        ) {
+        if (err.code === "MODULE_NOT_FOUND" && pkgJsonsAllowedToFail.includes(key)) {
           return;
         }
         throw err;
       }
       if (pkgJson.peerDependencies) {
         finalPeerDeps.push(...Object.keys(pkgJson.peerDependencies));
-        getChildPeerDeps(
-          finalPeerDeps,
-          isUMD,
-          Object.keys(pkgJson.peerDependencies),
-          doneDeps
-        );
+        getChildPeerDeps(finalPeerDeps, isUMD, Object.keys(pkgJson.peerDependencies), doneDeps);
       }
       // when we're building a UMD bundle, we're also bundling the dependencies so we need
       // to get the peerDependencies of dependencies
       if (pkgJson.dependencies && isUMD) {
         doneDeps.push(...Object.keys(pkgJson.dependencies));
-        getChildPeerDeps(
-          finalPeerDeps,
-          isUMD,
-          Object.keys(pkgJson.dependencies),
-          doneDeps
-        );
+        getChildPeerDeps(finalPeerDeps, isUMD, Object.keys(pkgJson.dependencies), doneDeps);
       }
     });
 }
@@ -92,7 +79,7 @@ export function toUnsafeRollupConfig(config: RollupConfig): Object {
   return config;
 }
 
-export type RollupConfigType = "umd" | "browser" | "node-dev" | "node-prod";
+export type RollupConfigType = "umd" | "browser" | "node-dev" | "node-prod" | "react-native";
 
 export let getRollupConfig = (
   pkg: StrictPackage,

--- a/src/fix.js
+++ b/src/fix.js
@@ -7,7 +7,8 @@ import {
   getValidModuleField,
   getValidMainField,
   getValidUmdMainField,
-  getValidBrowserField
+  getValidBrowserField,
+  getValidReactNativeField
 } from "./utils";
 import {
   validateEntrypoint,
@@ -15,7 +16,8 @@ import {
   isModuleFieldValid,
   isUmdMainFieldValid,
   isUmdNameSpecified,
-  isBrowserFieldValid
+  isBrowserFieldValid,
+  isReactNativeFieldValid
 } from "./validate";
 
 async function fixPackage(pkg: Package) {
@@ -45,6 +47,12 @@ async function fixPackage(pkg: Package) {
     didModify = true;
 
     pkg.browser = getValidBrowserField(pkg);
+  }
+
+  if (pkg.reactNative !== null && !isReactNativeFieldValid(pkg)) {
+    didModify = true;
+
+    pkg.reactNative = getValidReactNativeField(pkg);
   }
 
   await pkg.save();

--- a/src/messages.js
+++ b/src/messages.js
@@ -9,6 +9,7 @@ export let errors = {
   invalidMainField: "main field is invalid",
   invalidUmdMainField: "umd:main field is invalid",
   invalidBrowserField: "browser field is invalid",
+  invalidReactNativeField: "react-native field is invalid",
   umdNameNotSpecified:
     "the umd:main field is specified but a umdName option is not specified. please add it to the preconstruct field in your package.json",
   deniedWriteBrowserField:
@@ -47,7 +48,8 @@ export let infos = {
   validModuleField: "module field is valid",
   validUmdMainField: "umd:main field is valid",
   validEntrypoint: "a valid entry point exists.",
-  validBrowserField: "browser field is valid"
+  validBrowserField: "browser field is valid",
+  validReactNativeField: "react-native field is valid"
 };
 
 export let successes = {

--- a/src/package.js
+++ b/src/package.js
@@ -74,13 +74,16 @@ export class Package {
     this.json.module = path;
   }
   get browser(): null | string | { [key: string]: string } {
-    return is(
-      this.json.browser,
-      is.maybe(is.either(is.string, objectOfString))
-    );
+    return is(this.json.browser, is.maybe(is.either(is.string, objectOfString)));
   }
   set browser(option: string | { [key: string]: string }) {
     this.json.browser = option;
+  }
+  get reactNative(): null | string | { [key: string]: string } {
+    return is(this.json["react-native"], is.maybe(is.either(is.string, objectOfString)));
+  }
+  set reactNative(option: string | { [key: string]: string }) {
+    this.json["react-native"] = option;
   }
   get dependencies(): null | { [key: string]: string } {
     return is(this.json.dependencies, is.maybe(objectOfString));
@@ -91,10 +94,7 @@ export class Package {
   _config: Object;
 
   global(pkg: string) {
-    if (
-      this.parent._config.globals !== undefined &&
-      this.parent._config.globals[pkg]
-    ) {
+    if (this.parent._config.globals !== undefined && this.parent._config.globals[pkg]) {
       return this.parent._config.globals[pkg];
     } else {
       try {
@@ -108,23 +108,15 @@ export class Package {
           throw err;
         }
       }
-      throw askGlobalLimit(() =>
-        (async () => {
+      throw askGlobalLimit(() => (async () => {
           // if while we were waiting, that global was added, return
-          if (
-            this.parent._config.globals !== undefined &&
-            this.parent._config.globals[pkg]
-          ) {
+          if (this.parent._config.globals !== undefined && this.parent._config.globals[pkg]) {
             return;
           }
-          let response = await promptInput(
-            `What should the umdName of ${pkg} be?`,
-            this
-          );
+          let response = await promptInput(`What should the umdName of ${pkg} be?`, this);
           this.addGlobal(pkg, response);
           await this.save();
-        })()
-      );
+        })());
     }
   }
 
@@ -173,11 +165,7 @@ export class Package {
 
       let workspaces = is(_workspaces, is.arrayOf(is.string));
 
-      let packages = await promptInput(
-        "what packages should preconstruct build?",
-        this,
-        workspaces.join(",")
-      );
+      let packages = await promptInput("what packages should preconstruct build?", this, workspaces.join(","));
 
       this.parent._config.packages = packages.split(",");
 
@@ -191,9 +179,9 @@ export class Package {
         absolute: true
       });
 
-      let packages = await Promise.all(
-        filenames.map(x => Package.create(x, this))
-      );
+      let packages = await Promise.all(filenames.map(x =>
+          Package.create(x, this)
+        ));
       return packages;
     } catch (error) {
       if (error instanceof is.AssertionError) {
@@ -209,7 +197,9 @@ export class Package {
         onlyDirectories: true,
         absolute: true
       });
-      let packages = filenames.map(x => Package.createSync(x, this));
+      let packages = filenames.map(x =>
+        Package.createSync(x, this)
+      );
       return packages;
     } catch (error) {
       if (error instanceof is.AssertionError) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,6 +23,14 @@ export function getValidModuleBrowserPath(pkg: Package) {
   return getValidModuleField(pkg).replace("esm", "browser.esm");
 }
 
+export function getValidCjsReactNativePath(pkg: Package) {
+  return getValidMainField(pkg).replace("cjs", "native.cjs");
+}
+
+export function getValidModuleReactNativePath(pkg: Package) {
+  return getValidModuleField(pkg).replace("esm", "native.esm");
+}
+
 export function getValidBrowserField(pkg: Package) {
   let obj = {
     [`./${getValidMainField(pkg)}`]: "./" + getValidCjsBrowserPath(pkg)
@@ -30,6 +38,17 @@ export function getValidBrowserField(pkg: Package) {
   if (pkg.module !== null) {
     obj[`./${getValidModuleField(pkg)}`] =
       "./" + getValidModuleBrowserPath(pkg);
+  }
+  return obj;
+}
+
+export function getValidReactNativeField(pkg: Package) {
+  let obj = {
+    [`./${getValidMainField(pkg)}`]: "./" + getValidCjsReactNativePath(pkg)
+  };
+  if (pkg.module !== null) {
+    obj[`./${getValidModuleField(pkg)}`] =
+      "./" + getValidModuleReactNativePath(pkg);
   }
   return obj;
 }

--- a/src/validate.js
+++ b/src/validate.js
@@ -7,7 +7,8 @@ import {
   getValidModuleField,
   getValidMainField,
   getValidUmdMainField,
-  getValidBrowserField
+  getValidBrowserField,
+  getValidReactNativeField
 } from "./utils";
 import * as logger from "./logger";
 import equal from "fast-deep-equal";
@@ -41,6 +42,10 @@ export function isUmdMainFieldValid(pkg: Package) {
 
 export function isBrowserFieldValid(pkg: Package): boolean {
   return equal(pkg.browser, getValidBrowserField(pkg));
+}
+
+export function isReactNativeFieldValid(pkg: Package): boolean {
+  return equal(pkg.reactNative, getValidReactNativeField(pkg));
 }
 
 export function isUmdNameSpecified(pkg: Package) {
@@ -85,6 +90,13 @@ export function validatePackage(pkg: Package, log: boolean) {
       throw new FatalError(errors.invalidBrowserField, pkg);
     } else if (log) {
       logger.info(infos.validBrowserField, pkg);
+    }
+  }
+  if (pkg.reactNative !== null) {
+    if (typeof pkg.reactNative === "string" || !isReactNativeFieldValid(pkg)) {
+      throw new FatalError(errors.invalidReactNativeField, pkg);
+    } else if (log) {
+      logger.info(infos.validReactNativeField, pkg);
     }
   }
 }


### PR DESCRIPTION
Some changes were done by prettier integration in my VS Code. I suspect that it's because you have empty `.prettierrc` in the root and it has just used default settings. If it's an issue for you I'd suggest adding explicit configuration & lint-staged as precommit - let me know what you decide.

**DISCLAIMER** I have not yet tested this because I have problems with linking this locally to emotion, don't know why but `require` in linked `preconstruct` doesn't want to find `@emotion/hash` in `emotion` repo (probably any monorepo package~, but didn't test it either) while executing `getChildPeerDeps`. Maybe you could try it urself or cut a beta release so I can test it? 

**Why?**
It is supposed to fix https://github.com/emotion-js/emotion/pull/1080 , I want create same bundles as main/module, just with different filename and redirect both react-native & sketch to them.