### PR TITLE
Update `watch` to support latest rollup event info

### DIFF
--- a/src/build/watch.js
+++ b/src/build/watch.js
@@ -56,7 +56,11 @@ async function watchPackage(pkg: Package, aliases: Aliases) {
             `bundles ${chalk.bold(
               typeof event.input === "string"
                 ? relativePath(event.input)
-                : event.input.map(relativePath).join(", ")
+                : Array.isArray(event.input)
+                  ? event.input.map(relativePath).join(", ")
+                  : Object.values(event.input)
+                      .map(relativePath)
+                      .join(', ')
             )} → ${chalk.bold(event.output.map(relativePath).join(", "))}...`
           ),
           pkg


### PR DESCRIPTION
Taken from https://github.com/rollup/rollup/blob/master/bin/src/run/watch.ts#L116-L122

Specifically, this is for `rollup@1.1.0`.

NOTE: There is a separate bug (https://github.com/preconstruct/preconstruct/issues/21) for the `BUNDLE_END` event, which this PR does not address:

```
TypeError: Cannot read property '0' of undefined
```