### PR TITLE
Cache babel transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "meow": "^5.0.0",
     "ms": "^2.1.1",
     "p-limit": "^2.0.0",
+    "quick-lru": "^4.0.0",
     "resolve": "^1.10.0",
     "resolve-from": "^4.0.0",
     "rollup": "^1.0.0",
@@ -51,10 +52,10 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-pluginutils": "^2.6.0",
     "sarcastic": "^1.5.0",
-    "terser": "^3.14.1"
+    "terser": "^3.14.1",
+    "xxhash-wasm": "^0.3.1"
   },
   "devDependencies": {
-    "prettier": "^1.15.3",
     "@babel/cli": "^7.1.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
     "@babel/preset-env": "^7.1.0",
@@ -72,6 +73,7 @@
     "jest-in-case": "^1.0.2",
     "jest-junit": "^6.1.0",
     "object-assign": "^4.1.1",
+    "prettier": "^1.15.3",
     "react": "^16.6.3",
     "rimraf": "^2.6.2",
     "spawndamnit": "^2.0.0"

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -10,6 +10,7 @@ import { confirms, errors } from "../messages";
 import { FatalError } from "../errors";
 import { getRollupConfigs } from "./config";
 import { createWorker, destroyWorker } from "../worker-client";
+import { hasherPromise } from "../rollup-plugins/babel";
 
 let browserPattern = /typeof\s+(window|document)/;
 
@@ -68,7 +69,7 @@ export default async function build(directory: string) {
   // do more stuff with checking whether the repo is using yarn workspaces or bolt
   try {
     createWorker();
-
+    await hasherPromise;
     let project = await Project.create(directory);
 
     logger.info("building bundles!");

--- a/src/rollup-plugins/babel/index.js
+++ b/src/rollup-plugins/babel/index.js
@@ -2,6 +2,8 @@
 import * as babel from "@babel/core";
 import { createFilter } from "rollup-pluginutils";
 import { getWorker } from "../../worker-client";
+import initHasher from "xxhash-wasm";
+import QuickLRU from "quick-lru";
 
 const regExpCharactersRegExp = /[\\^$.*+?()[\]{}|]/g;
 const escapeRegExpCharacters = (str: string) =>
@@ -29,6 +31,14 @@ const unpackOptions = ({
   }
 });
 
+const lru = new QuickLRU({ maxSize: 1000 });
+
+let hasher;
+
+initHasher().then(({ h64 }) => {
+  hasher = h64;
+});
+
 let rollupPluginBabel = (pluginOptions: *) => {
   const { exclude, extensions, include, ...babelOptions } = unpackOptions(
     pluginOptions
@@ -44,9 +54,14 @@ let rollupPluginBabel = (pluginOptions: *) => {
     name: "babel",
     transform(code: string, filename: string) {
       if (!filter(filename)) return Promise.resolve(null);
+      let hash = hasher(code + filename);
+      if (lru.has(hash)) {
+        return lru.get(hash);
+      }
       let options = JSON.stringify({ ...babelOptions, filename });
-
-      return getWorker().transformBabel(code, options);
+      let promise = getWorker().transformBabel(code, options);
+      lru.set(hash, promise);
+      return promise;
     }
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4552,6 +4552,11 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
+quick-lru@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.0.tgz#a44d44010a776d787af65b1226566dd1ae7b9649"
+  integrity sha512-5cS39FEMrySKt/8c66v10HrmoexP2iYOsJBhtbVrlAr6Cbuc6khFMN8CHJG87c+QsdxBABivfVscgk20I/rPDw==
+
 randomatic@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
@@ -5730,6 +5735,11 @@ xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
+xxhash-wasm@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/xxhash-wasm/-/xxhash-wasm-0.3.1.tgz#2b8a7dbd9647d36a7eba8fd867cef08edab03394"
+  integrity sha512-amhCgCYQfhiQFvYjn6kvk4jmY1NXBn5MKdsS0jvxofmHFo77CBrXuV46NYeXACC3qTleugHYg7kNpeFnIA+R8Q==
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Closes #16 

Note that this only caches in memory, the cache is _not_ persisted to the file system(I don't want to open that can of worms). It's useful since each file was previously being transformed with the exact same transforms multiple times for different build types.