### PR TITLE
Fixing link to monorepo tutorial

### DIFF
--- a/site/src/pages/tutorials/index.mdx
+++ b/site/src/pages/tutorials/index.mdx
@@ -132,4 +132,4 @@ So now we can run `yarn release` to do a release.
 preconstruct can do a lot more than building a simple package like this. You can learn more about what preconstruct can do by going through preconstruct's other tutorials:
 
 - [Setting up a package exports multiple entrypoints](/tutorials/multiple-entrypoints)
-- [Setting up a monorepo with preconstruct](/tutorials/monorepo)
+- [Setting up a monorepo with preconstruct](/tutorials/monorepos)


### PR DESCRIPTION
Missing `s` in the link path :)