### PR TITLE
Add github link to website homepage

### DIFF
--- a/site/src/fancy-link.js
+++ b/site/src/fancy-link.js
@@ -2,30 +2,31 @@ import React from "react";
 import { Link } from "gatsby";
 import colors from "./colors";
 
-export let FancyLink = props => (
+export let LinksContainer = props => (
   <div
     css={{ display: "flex", justifyContent: "center", alignItems: "center" }}
-  >
-    <Link
-      css={{
-        display: "block",
-        color: "inherit",
-        textDecoration: "none",
-        fontWeight: "bold",
-        paddingLeft: 32,
-        paddingRight: 32,
-        paddingTop: 8,
-        paddingBottom: 8,
-        marginLeft: -32,
-        marginRight: -32,
-        border: `${colors.base} solid 4px`,
-        borderRadius: 8,
-        ":hover": {
-          backgroundColor: colors.base,
-          color: "white"
-        }
-      }}
-      {...props}
-    />
-  </div>
+    {...props}
+  />
 );
+
+let fancyCSS = {
+  display: "block",
+  color: "inherit",
+  textDecoration: "none",
+  fontWeight: "bold",
+  paddingLeft: 32,
+  paddingRight: 32,
+  paddingTop: 8,
+  paddingBottom: 8,
+  marginLeft: 8,
+  marginRight: 8,
+  border: `${colors.base} solid 4px`,
+  borderRadius: 8,
+  ":hover": {
+    backgroundColor: colors.base,
+    color: "white"
+  }
+};
+
+export let FancyLink = props => <Link css={fancyCSS} {...props} />;
+export let FancyAnchor = props => <a css={fancyCSS} {...props} />;

--- a/site/src/pages/index.mdx
+++ b/site/src/pages/index.mdx
@@ -1,4 +1,4 @@
-import { FancyLink } from "../fancy-link";
+import { LinksContainer, FancyLink, FancyAnchor } from "../fancy-link";
 
 <h1 style={{textAlign:'center'}}> 🎁</h1>
 
@@ -6,7 +6,15 @@ import { FancyLink } from "../fancy-link";
 
 <h2 style={{ textAlign:'center' }}>A smart build tool for libraries</h2>
 
-<FancyLink to="/getting-started">Getting Started</FancyLink>
+<LinksContainer>
+  <FancyLink to="/getting-started">Getting Started</FancyLink>
+  <FancyAnchor
+    href="https://github.com/preconstruct/preconstruct"
+    target="_blank"
+  >
+    Source on GitHub
+  </FancyAnchor>
+</LinksContainer>
 
 <div style={{ paddingBottom: 16 }} />
 


### PR DESCRIPTION
Just a little paper cut - I meant to go to the repo and ended up at https://preconstruct.tools (because autosuggest)

Then realised there's actually no link to the repo from the website, so I added one