### PR TITLE
Windows compatibility

### DIFF
--- a/.changeset/dirty-dolphins-design/changes.json
+++ b/.changeset/dirty-dolphins-design/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "preconstruct", "type": "patch" }], "dependents": [] }

--- a/.changeset/dirty-dolphins-design/changes.md
+++ b/.changeset/dirty-dolphins-design/changes.md
@@ -1,0 +1,1 @@
+support windows paths

--- a/packages/preconstruct/src/__tests__/dev.js
+++ b/packages/preconstruct/src/__tests__/dev.js
@@ -64,10 +64,10 @@ test("all the build types", async () => {
       path.join(distPath, "all-the-build-types.cjs.js"),
       "utf-8"
     ))
-      .replace(/require\('[^']+'\)/g, "thisWasARequireCall()")
-      .replace(/___internalHook\('[^']+'\)/, "thisWasA___internalHookCall()")
+      .replace(/require\("[^"]+"\)/g, "thisWasARequireCall()")
+      .replace(/___internalHook\("[^"]+"\)/, "thisWasA___internalHookCall()")
   ).toMatchInlineSnapshot(`
-"'use strict';
+"\\"use strict\\";
 
 let unregister = thisWasARequireCall().thisWasA___internalHookCall();
 

--- a/packages/preconstruct/src/dev.js
+++ b/packages/preconstruct/src/dev.js
@@ -23,7 +23,7 @@ function cjsOnlyReexportTemplate(pathToSource: string) {
 // run preconstruct dev again which wouldn't be ideal
 // this solution could change but for now, it's working
 
-module.exports = require("${pathToSource}")
+module.exports = require(${JSON.stringify(pathToSource)})
 `;
 }
 

--- a/packages/preconstruct/src/dev.js
+++ b/packages/preconstruct/src/dev.js
@@ -86,6 +86,11 @@ async function writeFlowFile(typeSystemPromise, entrypoint) {
   }
 }
 
+// escape backslashes such as in windows file paths
+function escape(filePath: string) {
+    return filePath.replace(/\\/g, '\\\\');
+}
+
 export default async function dev(projectDir: string) {
   let project: Project = await Project.create(projectDir);
   project.packages.forEach(({ entrypoints }) =>
@@ -110,9 +115,9 @@ export default async function dev(projectDir: string) {
               path.join(entrypoint.directory, entrypoint.main),
               `'use strict';
 
-let unregister = require('${require.resolve(
+let unregister = require('${escape(require.resolve(
                 "@preconstruct/hook"
-              )}').___internalHook('${project.directory}');
+              ))}').___internalHook('${escape(project.directory)}');
 
 module.exports = require('${entrypoint.source}');
 

--- a/packages/preconstruct/src/dev.js
+++ b/packages/preconstruct/src/dev.js
@@ -86,11 +86,6 @@ async function writeFlowFile(typeSystemPromise, entrypoint) {
   }
 }
 
-// escape backslashes such as in windows file paths
-function escape(filePath: string) {
-    return filePath.replace(/\\/g, '\\\\');
-}
-
 export default async function dev(projectDir: string) {
   let project: Project = await Project.create(projectDir);
   project.packages.forEach(({ entrypoints }) =>
@@ -113,13 +108,13 @@ export default async function dev(projectDir: string) {
             writeFlowFile(typeSystemPromise, entrypoint),
             fs.writeFile(
               path.join(entrypoint.directory, entrypoint.main),
-              `'use strict';
+              `"use strict";
 
-let unregister = require('${escape(require.resolve(
-                "@preconstruct/hook"
-              ))}').___internalHook('${escape(project.directory)}');
+let unregister = require(${JSON.stringify(
+                require.resolve("@preconstruct/hook")
+              )}).___internalHook(${JSON.stringify(project.directory)});
 
-module.exports = require('${entrypoint.source}');
+module.exports = require(${JSON.stringify(entrypoint.source)});
 
 unregister();
 `


### PR DESCRIPTION
* Escape strings in order to support windows paths with forward slashes.

There is a code-style decision - In this implementation the generated code uses double quotes instead of single quotes. Some users may care about this. 🤔Ideally it would be configurable?