### PR TITLE
Add typescript types support

### DIFF
--- a/__fixtures__/typescript/package.json
+++ b/__fixtures__/typescript/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "private": true,
   "module": "dist/typescript.esm.js",
+  "types": "dist/typescript.cjs.js.ts",
   "dependencies": {
     "@babel/core": "^7.4.3",
     "@babel/preset-typescript": "^7.3.3",

--- a/packages/preconstruct/src/__tests__/fix.js
+++ b/packages/preconstruct/src/__tests__/fix.js
@@ -221,3 +221,31 @@ Object {
     expect(promptInput).toBeCalledTimes(1);
   }
 );
+
+test("fix types", async () => {
+  let tmpPath = f.copy("typescript");
+
+  await modifyPkg(tmpPath, pkg => {
+    pkg.types = "bad.js";
+  });
+
+  await fix(tmpPath);
+
+  expect(await getPkg(tmpPath)).toMatchInlineSnapshot(`
+Object {
+  "dependencies": Object {
+    "@babel/core": "^7.4.3",
+    "@babel/preset-typescript": "^7.3.3",
+    "@types/node": "^12.7.1",
+    "typescript": "^3.4.5",
+  },
+  "license": "MIT",
+  "main": "dist/typescript.cjs.js",
+  "module": "dist/typescript.esm.js",
+  "name": "typescript",
+  "private": true,
+  "types": "dist/typescript.cjs.js.ts",
+  "version": "1.0.0",
+}
+`);
+});

--- a/packages/preconstruct/src/__tests__/validate.js
+++ b/packages/preconstruct/src/__tests__/validate.js
@@ -227,3 +227,46 @@ test("entrypoint not included in package", async () => {
   }
   expect(true).toBe(false);
 });
+
+test("invalid types", async () => {
+  let tmpPath = f.copy("typescript");
+
+  await modifyPkg(tmpPath, pkg => {
+    pkg.types = "invalid.js";
+  });
+
+  try {
+    await validate(tmpPath);
+  } catch (e) {
+    expect(e).toBeInstanceOf(FatalError);
+    expect(e.message).toBe(errors.invalidTypesField);
+  }
+});
+
+test("valid types", async () => {
+  let tmpPath = f.copy("typescript");
+
+  await validate(tmpPath);
+  expect(logMock.log.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "🎁 info typescript a valid entry point exists.",
+  ],
+  Array [
+    "🎁 info typescript main field is valid",
+  ],
+  Array [
+    "🎁 info typescript module field is valid",
+  ],
+  Array [
+    "🎁 info typescript types field is valid",
+  ],
+  Array [
+    "🎁 info typescript package entrypoints are valid",
+  ],
+  Array [
+    "🎁 success project is valid!",
+  ],
+]
+`);
+});

--- a/packages/preconstruct/src/build/__tests__/__snapshots__/other.js.snap
+++ b/packages/preconstruct/src/build/__tests__/__snapshots__/other.js.snap
@@ -326,6 +326,7 @@ exports[`typescript: package.json 1`] = `
   \\"license\\": \\"MIT\\",
   \\"private\\": true,
   \\"module\\": \\"dist/typescript.esm.js\\",
+  \\"types\\": \\"dist/typescript.cjs.js.ts\\",
   \\"dependencies\\": {
     \\"@babel/core\\": \\"^7.4.3\\",
     \\"@babel/preset-typescript\\": \\"^7.3.3\\",

--- a/packages/preconstruct/src/entrypoint.js
+++ b/packages/preconstruct/src/entrypoint.js
@@ -18,7 +18,7 @@ let fields = [
 
 function setFieldInOrder(
   obj,
-  field: "main" | "module" | "umd:main" | "browser",
+  field: "main" | "module" | "umd:main" | "browser" | "types",
   value
 ) {
   if (field in obj) {
@@ -95,6 +95,13 @@ export class Entrypoint extends Item {
   }
   set umdMain(path: string) {
     this.json = setFieldInOrder(this.json, "umd:main", path);
+  }
+
+  get types(): string | null {
+    return is(this.json.types, is.maybe(is.string));
+  }
+  set types(path: string) {
+    this.json = setFieldInOrder(this.json, "types", path);
   }
 
   get configSource(): string {

--- a/packages/preconstruct/src/messages.js
+++ b/packages/preconstruct/src/messages.js
@@ -10,6 +10,7 @@ export let errors = {
   invalidMainField: "main field is invalid",
   invalidUmdMainField: "umd:main field is invalid",
   invalidBrowserField: "browser field is invalid",
+  invalidTypesField: "types field is invalid",
   umdNameNotSpecified: `the umd:main field is specified but a umdName option is not specified. please add it to the ${PKG_JSON_CONFIG_FIELD} field in your package.json`,
   deniedWriteBrowserField:
     "building browser bundles for modules that include typeof" +
@@ -34,6 +35,9 @@ export let confirms = {
   ),
   fixUmdBuild: createPromptConfirmLoader(
     "would you like to fix the umd field?"
+  ),
+  fixTypesField: createPromptConfirmLoader(
+    "would you like to fix the types field?"
   ),
   shouldInstallObjectAssign: createPromptConfirmLoader(
     "Object.assign is polyfilled with object-assign to reduce bundle size when used with react. would you like to install object-assign automatically?"
@@ -64,6 +68,7 @@ export let infos = {
   validUmdMainField: "umd:main field is valid",
   validEntrypoint: "a valid entry point exists.",
   validBrowserField: "browser field is valid",
+  validTypesField: "types field is valid",
   validPackageEntrypoints: "package entrypoints are valid"
 };
 

--- a/packages/preconstruct/src/package.js
+++ b/packages/preconstruct/src/package.js
@@ -63,7 +63,7 @@ export class Package extends Item {
         for (let descriptor of descriptors) {
           if (descriptor.contents !== null) {
             let parsed = JSON.parse(descriptor.contents);
-            for (let field of ["module", "umd:main"]) {
+            for (let field of ["module", "umd:main", "types"]) {
               if (parsed[field] !== undefined) {
                 plainEntrypointObj[
                   field
@@ -115,7 +115,7 @@ export class Package extends Item {
     return pkg;
   }
 
-  setFieldOnEntrypoints(field: "main" | "browser" | "module" | "umdMain") {
+  setFieldOnEntrypoints(field: "main" | "browser" | "module" | "umdMain" | "types") {
     this.entrypoints.forEach(entrypoint => {
       switch (field) {
         case "main": {
@@ -143,6 +143,13 @@ export class Package extends Item {
         case "umdMain": {
           entrypoint.umdMain = getValidStringFieldContentForBuildType(
             "umd:main",
+            this.name
+          );
+          break;
+        }
+        case "types": {
+          entrypoint.types = getValidStringFieldContentForBuildType(
+            "types",
             this.name
           );
           break;

--- a/packages/preconstruct/src/utils.js
+++ b/packages/preconstruct/src/utils.js
@@ -5,7 +5,7 @@ export function getNameForDist(name: string): string {
 }
 
 export function getValidStringFieldContentForBuildType(
-  type: "main" | "module" | "umd:main",
+  type: "main" | "module" | "umd:main" | "types",
   pkgName: string
 ) {
   let safeName = getNameForDist(pkgName);
@@ -18,6 +18,9 @@ export function getValidStringFieldContentForBuildType(
     }
     case "umd:main": {
       return `dist/${safeName}.umd.min.js`;
+    }
+    case "types": {
+      return `dist/${safeName}.cjs.js.ts`;
     }
   }
   throw new Error(

--- a/packages/preconstruct/src/validate-package.js
+++ b/packages/preconstruct/src/validate-package.js
@@ -11,7 +11,8 @@ let camelToPkgJsonField = {
   main: "main",
   module: "module",
   umdMain: "umd:main",
-  browser: "browser"
+  browser: "browser",
+  types: "types",
 };
 
 export async function fixPackage(pkg: Package) {
@@ -22,7 +23,8 @@ export async function fixPackage(pkg: Package) {
     main: true,
     module: pkg.entrypoints.some(x => x.module),
     umdMain: pkg.entrypoints.some(x => x.umdMain),
-    browser: pkg.entrypoints.some(x => x.browser)
+    browser: pkg.entrypoints.some(x => x.browser),
+    types: pkg.entrypoints.some(x => x.types),
   };
 
   Object.keys(fields)
@@ -46,7 +48,8 @@ export function validatePackage(pkg: Package) {
     // which this function validates will never happen
     module: !!pkg.entrypoints[0].module,
     umdMain: !!pkg.entrypoints[0].umdMain,
-    browser: !!pkg.entrypoints[0].browser
+    browser: !!pkg.entrypoints[0].browser,
+    types: !!pkg.entrypoints[0].types
   };
 
   pkg.entrypoints.forEach(entrypoint => {

--- a/packages/preconstruct/src/validate.js
+++ b/packages/preconstruct/src/validate.js
@@ -68,6 +68,14 @@ export function isBrowserFieldValid(entrypoint: Entrypoint): boolean {
   );
 }
 
+export function isTypesFieldValid(entrypoint: Entrypoint) {
+        require('fs').writeFileSync('test.json', JSON.stringify(getValidStringFieldContentForBuildType("types", entrypoint.package.name)));
+  return (
+    entrypoint.types ===
+    getValidStringFieldContentForBuildType("types", entrypoint.package.name)
+  );
+}
+
 export function isUmdNameSpecified(entrypoint: Entrypoint) {
   return typeof entrypoint._config.umdName === "string";
 }
@@ -113,6 +121,17 @@ export function validateEntrypoint(entrypoint: Entrypoint, log: boolean) {
       throw new FixableError(errors.invalidBrowserField, entrypoint.name);
     } else if (log) {
       logger.info(infos.validBrowserField, entrypoint.name);
+    }
+  }
+  if (entrypoint.types !== null) {
+    if (
+      isTypesFieldValid(entrypoint)
+    ) {
+      if (log) {
+        logger.info(infos.validTypesField, entrypoint.name);
+      }
+    } else {
+      throw new FixableError(errors.invalidTypesField, entrypoint.name);
     }
   }
 }


### PR DESCRIPTION
Hi,

I was trying use `preconstruct` in our `typescript` mono-repo but I found that it doesn't fix the `types` field. So, I added it. Let me know if you want me to change anything.

Cheers