### PR TITLE
adding documentation on entrypoints

### DIFF
--- a/site/src/gatsby-theme-sidebar/root.js
+++ b/site/src/gatsby-theme-sidebar/root.js
@@ -240,6 +240,9 @@ export default ({
               <NavLink to="/guides/building-typescript-packages">
                 Building TypeScript packages
               </NavLink>
+              <NavLink to="/guides/adding-a-second-entrypoint">
+                Adding a Second Entrypoint
+              </NavLink>
             </div>
             <NavLink to="/commands">Commands</NavLink>
             <div css={{ marginLeft: 16 }}>

--- a/site/src/pages/config/entrypoints.mdx
+++ b/site/src/pages/config/entrypoints.mdx
@@ -6,7 +6,7 @@ Entrypoints are the lowest level configuration point and describe a set of bundl
 
 `string`
 
-`source` specifies the source file to use for a given entrypoint. It's resolved relative to the package.json where it's specified. This
+`source` specifies the source file to use for a given entrypoint. It's resolved relative to the package.json where it's specified.
 
 ### Default
 

--- a/site/src/pages/config/entrypoints.mdx
+++ b/site/src/pages/config/entrypoints.mdx
@@ -1,6 +1,6 @@
 # Entrypoints
 
-Entrypoints are the lowest level configuration point and describe a set of bundles for a particular entrypoint. They are configured by the `package.json` in the folder of the entrypoint. We also have a guide on [adding a second entrypoint](/guides/adding-a-second-entrypoing)
+Entrypoints are the lowest level configuration point and describe a set of bundles for a particular entrypoint. They are configured by the `package.json` in the folder of the entrypoint. We also have a guide on [adding a second entrypoint](/guides/adding-a-second-entrypoint)
 
 ## `source`
 

--- a/site/src/pages/config/entrypoints.mdx
+++ b/site/src/pages/config/entrypoints.mdx
@@ -1,12 +1,12 @@
 # Entrypoints
 
-Entrypoints are the lowest level configuration point and describe a set of bundles for a particular entrypoint.
+Entrypoints are the lowest level configuration point and describe a set of bundles for a particular entrypoint. They are configured by the `package.json` in the folder of the entrypoint. We also have a guide on [adding a second entrypoint](/guides/adding-a-second-entrypoing)
 
 ## `source`
 
 `string`
 
-`source` specifies the source file to use for a given entrypoint. It's resolved relative to the package.json where it's specified.
+`source` specifies the source file to use for a given entrypoint. It's resolved relative to the package.json where it's specified. This
 
 ### Default
 

--- a/site/src/pages/guides/adding-a-second-entrypoint.mdx
+++ b/site/src/pages/guides/adding-a-second-entrypoint.mdx
@@ -75,7 +75,7 @@ The next thing we need to do is tell the new `awesome` entrypoint where to find 
 }
 ```
 
-This tells this entrypoint where to fine the source code it should bundle to here.
+This tells this entrypoint where to find the source code it should bundle to here.
 
 Finally, run
 

--- a/site/src/pages/guides/adding-a-second-entrypoint.mdx
+++ b/site/src/pages/guides/adding-a-second-entrypoint.mdx
@@ -1,0 +1,110 @@
+# Adding a second entrypoint
+
+When adding a second entrypoint, you are creating a second place where a package can be accessed from. Note that much of the time you do not need a second entrypoint. We have a guide on [when to use multiple entrypoints](/guides/when-should-i-use-multiple-entrypoints).
+
+So, let's assume we have a package called `emoji-uid` that gets us three random emojis, but we want to make a second function that only uses the best emojis. What we want to be able to do is write is:
+
+```js
+import getEmojiId from "emoji-uid";
+import getAwesomeId from "emoji-uid/awesome";
+```
+
+With `preconstruct`'s base setup, this isn't possible, so we will need to add a new `awesome` entrypoint.
+
+First, our project structure looks like:
+
+```
+- src
+    /index.js
+- package.json
+```
+
+and our package.json looks like:
+
+```json
+{
+  "name": "emoji-uid",
+  "version": "1.0.2",
+  "description": "Get 🔥 UIDs to help make things 💯",
+  "main": "dist/emoji-uid/.cjs.js",
+  "preconstruct": {
+    "source": "src/index.js"
+  }
+}
+```
+
+Let's assume we've written our new function and written it to `src/awesomenewFunction.js`
+
+The first bit of config we need to do is to add an `entrypoints` field to our preconstruct config. We should modify this in our package.json to read:
+
+```json
+  "preconstruct": {
+    "source": "src/index.js"
+    "entrypoints": [".", "awesome"]
+  },
+```
+
+This tells preconstruct to look for these two entrypoints. We have written out two, as the first is preconstruct's default entrypoint which we still want to include.
+
+Next, we will want to do to add the location the entrypoint resolves to. We are going to add a new directory with its own `package.json` that represents this. We can run:
+
+```bash
+mkdir awesome
+touch awesome/package.json
+```
+
+After all this, our project should look like:
+
+```
+- src
+    /index.js
+    /awesomeNewFunction.js
+- package.json
+- awesome
+    /package.json
+```
+
+The next thing we need to do is tell the new `awesome` entrypoint where to find the source file that it should be bundling from. If we open it up, we want to make it look like:
+
+```json
+{
+  "main": "dist/emoji-uid.cjs.js",
+  "preconstruct": {
+    "source": "../src/awesomeNewFunction"
+  }
+}
+```
+
+This tells this entrypoint where to fine the source code it should bundle to here.
+
+Finally, run
+
+```bash
+yarn preconstruct dev
+```
+
+to get set up for development. Preconstruct's CLI will alert you to any problems you are still encountering and provide guides on how to resolve them.
+
+## Got stuck?
+
+For further documentation, we recommend reading:
+
+- [the package configuration options](/config/packages)
+- [the entrypoint package.json configuration options](/config/entrypoints)
+
+### I don't have a `preconstruct` field in my package.json
+
+That's fine! If you haven't needed to add this field yet, you can add it with just add the precontsruct field so your `package.json` looks like:
+
+```json
+{
+  "name": "emoji-uid",
+  "version": "1.0.2",
+  "description": "Get 🔥 UIDs to help make things 💯",
+  "main": "dist/emoji-uid/.cjs.js",
+  "preconstruct": {
+    "entrypoints": [".", "awesome"]
+  },
+  "files": ["dist"]
+}
+```

--- a/site/src/pages/guides/adding-a-second-entrypoint.mdx
+++ b/site/src/pages/guides/adding-a-second-entrypoint.mdx
@@ -26,7 +26,7 @@ and our package.json looks like:
   "name": "emoji-uid",
   "version": "1.0.2",
   "description": "Get 🔥 UIDs to help make things 💯",
-  "main": "dist/emoji-uid/.cjs.js",
+  "main": "dist/emoji-uid.cjs.js",
   "preconstruct": {
     "source": "src/index.js"
   }


### PR DESCRIPTION
`emoji-uid` was just a cute example package - should possibly not be this, or I should make `emoji-uid` work like this if you just run these commands.

Otherwise I think this gives good structure.

Thing-I-want-to-tackle-somewhere - explaining configs better. I don't know *how* because I just skipped the config index and just went for configs relating to what I wanted, but understanding that these are configs to go in different `package.json`s for different purposes feels like it needs to be referenced in each somehow neatly.