### PR TITLE
Fixed distfile check failing on Windows

### DIFF
--- a/.changeset/metal-turkeys-notice.md
+++ b/.changeset/metal-turkeys-notice.md
@@ -1,5 +1,5 @@
 ---
-"preconstruct": minor
+"preconstruct": patch
 ---
 
 Fixed distfile check failing on Windows due to path separator mismatch

--- a/.changeset/metal-turkeys-notice.md
+++ b/.changeset/metal-turkeys-notice.md
@@ -1,0 +1,5 @@
+---
+"preconstruct": minor
+---
+
+Fixed distfile check failing on Windows due to path separator mismatch

--- a/.changeset/metal-turkeys-notice.md
+++ b/.changeset/metal-turkeys-notice.md
@@ -2,4 +2,4 @@
 "preconstruct": patch
 ---
 
-Fixed distfile check failing on Windows due to path separator mismatch
+Fixed dist file check failing on Windows due to path separator mismatch

--- a/packages/preconstruct/src/validate-included-files.ts
+++ b/packages/preconstruct/src/validate-included-files.ts
@@ -20,6 +20,13 @@ export async function validateIncludedFiles(pkg: Package) {
     );
 
     let result = await packlist({ path: pkg.directory });
+
+    // Ensure consistent path separators. Without this, there's a mismatch between this result and the path it
+    // checks on Windows. This value will have a forward slash (dist/preconstruct-test-file), whereas the value
+    // of distFilePath below will have a backslash (dist\preconstruct-test-file). Obviously these two won't match,
+    // so the distfile check will fail.
+    result = result.map(p => path.normalize(p));
+
     // check that we're including the package.json and main file
     // TODO: add Flow and TS check and if they're ignored, don't write them
     let messages: string[] = [];


### PR DESCRIPTION
Preconstruct wasn't running properly on Windows since it was trying to match "dist\preconstruct-test-file" (the value of distFilePath on Windows) against "dist/preconstruct-test-file" (the value returned by packlist). It looks like packlist doesn't normalize paths before returning them, so do that here before checking.