### PR TITLE
Fix yarn add within workspaces

### DIFF
--- a/site/src/pages/tutorials/monorepo.mdx
+++ b/site/src/pages/tutorials/monorepo.mdx
@@ -47,7 +47,7 @@ export default 2;
 Now that we have Yarn workspaces and our packages setup, we can install and setup Preconstruct.
 
 ```bash
-yarn add @preconstruct/cli
+yarn add @preconstruct/cli -W
 ```
 
 ```bash


### PR DESCRIPTION
Without the `-W` flag, `yarn add` returns an error:

```console
$ yarn add @preconstruct/cli
yarn add v1.17.3
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```