### PR TITLE
feat: improve searchDeps error message content

### DIFF
--- a/.changeset/chilly-days-wash.md
+++ b/.changeset/chilly-days-wash.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+improve searchDeps error message content

--- a/.changeset/chilly-days-wash.md
+++ b/.changeset/chilly-days-wash.md
@@ -2,4 +2,4 @@
 "@preconstruct/cli": patch
 ---
 
-improve searchDeps error message content
+Improve error message when attempting to create a TypeScript declaration file for a non-TypeScript file

--- a/packages/cli/src/rollup-plugins/typescript-declarations/create-generator.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/create-generator.ts
@@ -64,7 +64,8 @@ let getService = weakMemoize((typescript: Typescript) =>
 );
 
 export async function createDeclarationCreator(
-  dirname: string
+  dirname: string,
+  pkgName: string
 ): Promise<{
   getDeps: (entrypoints: Array<string>) => Set<string>;
   getDeclarationFile: (
@@ -129,7 +130,7 @@ export async function createDeclarationCreator(
           if (!sourceFile) {
             throw new FatalError(
               `Could not generate type declarations because ${dep} does not exist or is not a TypeScript file`,
-              dep
+              pkgName
             );
           }
           let internalDeps = new Set<string>();

--- a/packages/cli/src/rollup-plugins/typescript-declarations/create-generator.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/create-generator.ts
@@ -1,6 +1,7 @@
 import resolveFrom from "resolve-from";
 import * as fs from "fs-extra";
 import path from "path";
+import { FatalError } from "../../errors";
 // @ts-ignore
 import { createLanguageServiceHostClass } from "./language-service-host";
 
@@ -126,8 +127,9 @@ export async function createDeclarationCreator(
         for (let dep of deps) {
           let sourceFile = program!.getSourceFile(dep);
           if (!sourceFile) {
-            throw new Error(
-              "This is an internal error, please open an issue if you see this: source file not found"
+            throw new FatalError(
+              `Could not generate type declarations because ${dep} does not exist or is not a TypeScript file`,
+              dep
             );
           }
           let internalDeps = new Set<string>();

--- a/packages/cli/src/rollup-plugins/typescript-declarations/index.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/index.ts
@@ -16,7 +16,7 @@ export default function typescriptDeclarations(pkg: Package): Plugin {
 
     // eslint-disable-next-line no-unused-vars
     async generateBundle(opts, bundle, something) {
-      let creator = await createDeclarationCreator(pkg.directory);
+      let creator = await createDeclarationCreator(pkg.directory, pkg.name);
 
       let srcFilenameToDtsFilenameMap = new Map<string, string>();
 


### PR DESCRIPTION
This PR improves the error message given when there is a problem when TypeScript declarations could not be generated.

Ref issue: https://github.com/preconstruct/preconstruct/issues/236