### PR TITLE
Fixed issue with temporarily created files not being cleaned up

### DIFF
--- a/.changeset/cyan-poems-help.md
+++ b/.changeset/cyan-poems-help.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Fixed issue with temporarily created files (during validation) not being cleaned up correctly on validation error.


### PR DESCRIPTION
This could not get executed in full:
https://github.com/preconstruct/preconstruct/blob/d8dce6f0a3a9e144c14f6f0ff8c01bef18406fe0/packages/cli/src/validate-included-files.ts#L62-L70
because first thrown error was thrown up to the root-catch-handler and caused:
https://github.com/preconstruct/preconstruct/blob/1e37a5de036ca4f897c990457676c33a6ae287bc/packages/cli/src/cli.ts#L104

This, in turn, has terminated the program - in the middle of the cleanup.