### PR TITLE
Allow to build UMD files for packages having dependencies with top-level `this` in ESM files

### DIFF
--- a/.changeset/fluffy-carrots-compete.md
+++ b/.changeset/fluffy-carrots-compete.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Allow to build UMD files for packages having dependencies with top-level `this` in ESM files. This can often happen if a dependency package is transpiled down to ES5 using TypeScript.

--- a/packages/cli/src/__tests__/dev.ts
+++ b/packages/cli/src/__tests__/dev.ts
@@ -39,14 +39,14 @@ test("dev command works in node", async () => {
 
     "packages/package-one/src/index.js": js`
                                            import { message } from "@my-cool-scope/package-two";
-                                           
+
                                            console.log("message from package one");
                                            console.log(message);
                                          `,
 
     "packages/package-two/src/index.js": js`
                                            console.log("message from package two");
-                                           
+
                                            export let message = "message from package two but logged by package one";
                                          `,
   });
@@ -178,9 +178,9 @@ test("source maps work", async () => {
     }),
     "src/index.js": js`
                       class Bar {}
-                      
+
                       export class Foo extends Bar {}
-                      
+
                       throw new Error("i'm thrown on line 5");
                     `,
   });
@@ -235,21 +235,21 @@ test("flow", async () => {
 
     "src/index.js": js`
                       // @flow
-                      
+
                       export let something = true;
                     `,
 
     "a/src/index.js": js`
                         // @flow
-                        
+
                         export default "something";
                       `,
 
     "b/src/index.js": js`
                         // @flow
-                        
+
                         let something = true;
-                        
+
                         export { something as default };
                       `,
   });

--- a/packages/cli/src/__tests__/init.ts
+++ b/packages/cli/src/__tests__/init.ts
@@ -103,7 +103,7 @@ test("scoped package", async () => {
 
     "src/index.js": js`
                       // @flow
-                      
+
                       export default "something";
                     `,
   });

--- a/packages/cli/src/__tests__/validate.ts
+++ b/packages/cli/src/__tests__/validate.ts
@@ -56,7 +56,7 @@ test("no main field", async () => {
 
     "src/index.js": js`
                       // @flow
-                      
+
                       export default "something";
                     `,
   });
@@ -192,13 +192,13 @@ test("one-entrypoint-with-browser-field-one-without", async () => {
 
     "src/multiply.js": js`
                          import { identity } from "./identity";
-                         
+
                          export let multiply = (a, b) => identity(a * b);
                        `,
 
     "src/sum.js": js`
                     import { identity } from "./identity";
-                    
+
                     export let sum = (a, b) => identity(a + b);
                   `,
   });
@@ -338,7 +338,7 @@ test("monorepo umd with dep on other module incorrect peerDeps", async () => {
 
     "packages/package-one/src/index.js": js`
                                            import { createElement } from "react";
-                                           
+
                                            createElement("div", null);
                                          `,
 
@@ -348,7 +348,7 @@ test("monorepo umd with dep on other module incorrect peerDeps", async () => {
 
     "packages/package-two/src/index.js": js`
                                            import { createElement } from "react";
-                                           
+
                                            createElement("h1", null);
                                          `,
   });

--- a/packages/cli/src/build/__tests__/basic.ts
+++ b/packages/cli/src/build/__tests__/basic.ts
@@ -70,7 +70,7 @@ test("typescript thing", async () => {
     ),
     "src/index.ts": ts`
                       import { makeThing } from "./thing";
-                      
+
                       export const thing = makeThing();
                     `,
 
@@ -80,7 +80,7 @@ test("typescript thing", async () => {
 
     "src/thing.tsx": tsx`
                        import { thing } from "./other";
-                       
+
                        export const makeThing = () => thing();
                      `,
 

--- a/packages/cli/src/build/__tests__/build.ts
+++ b/packages/cli/src/build/__tests__/build.ts
@@ -116,11 +116,11 @@ test("flow", async () => {
 
     "src/index.js": js`
                       // @flow
-                      
+
                       export function doSomething(arg: string): string {
                         return "something" + arg;
                       }
-                      
+
                       export { default as something } from "./a";
                     `,
   });
@@ -144,11 +144,11 @@ test("flow", async () => {
     }),
     "src/index.js": js`
                       // @flow
-                      
+
                       export function doSomething(arg: string): string {
                         return "something" + arg;
                       }
-                      
+
                       export default "wow";
                     `,
   });
@@ -212,7 +212,7 @@ test("umd with dep on other module", async () => {
     },
     "src/index.js": js`
                       import { createElement } from "react";
-                      
+
                       createElement("div", null);
                     `,
   });
@@ -345,7 +345,7 @@ test("monorepo umd with dep on other module", async () => {
 
     "packages/package-one/src/index.js": js`
                                            import { createElement } from "react";
-                                           
+
                                            createElement("div", null);
                                          `,
 
@@ -355,7 +355,7 @@ test("monorepo umd with dep on other module", async () => {
 
     "packages/package-two/src/index.js": js`
                                            import { createElement } from "react";
-                                           
+
                                            createElement("h1", null);
                                          `,
   });
@@ -454,7 +454,7 @@ test("json", async () => {
 
     "src/index.js": js`
                       import changesetsSchema from "./schema.json";
-                      
+
                       export let schema = changesetsSchema;
                     `,
 

--- a/packages/cli/src/build/__tests__/entrypoints.ts
+++ b/packages/cli/src/build/__tests__/entrypoints.ts
@@ -73,7 +73,7 @@ test("source entrypoint option flow", async () => {
     }),
     "modules/index.js": js`
                           // @flow
-                          
+
                           export let something = "";
                         `,
   });
@@ -267,17 +267,17 @@ test("two entrypoints with a common dependency", async () => {
 
     "src/multiply.js": js`
                          import { identity } from "./identity";
-                         
+
                          export let multiply = (a, b) => identity(a * b);
-                         
+
                          export { identity };
                        `,
 
     "src/sum.js": js`
                     import { identity } from "./identity";
-                    
+
                     export let sum = (a, b) => identity(a + b);
-                    
+
                     export { identity };
                   `,
   });
@@ -317,7 +317,7 @@ test("two entrypoints where one requires the other entrypoint", async () => {
 
     "src/multiply.js": js`
                          import { identity } from "./identity";
-                         
+
                          export let multiply = (a, b) => identity(a * b);
                        `,
   });

--- a/packages/cli/src/build/__tests__/other.ts
+++ b/packages/cli/src/build/__tests__/other.ts
@@ -785,3 +785,26 @@ test("builds umd with a dependency containing top-level this in ESM", async () =
     {"version":3,"file":"pkg.umd.min.js","sources":["../node_modules/with-top-level-this-in-esm/index.js"],"sourcesContent":["// output transpiled by TS with inlined tslib helper\\nvar __assign =\\n  (this && this.__assign) ||\\n  function () {\\n    __assign =\\n      Object.assign ||\\n      function (t) {\\n        for (var s, i = 1, n = arguments.length; i < n; i++) {\\n          s = arguments[i];\\n          for (var p in s)\\n            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];\\n        }\\n        return t;\\n      };\\n    return __assign.apply(this, arguments);\\n  };\\nvar foo = { bar: 42 };\\nexport default __assign({}, foo);"],"names":["__assign","Object","assign","t","s","i","n","arguments","length","p","prototype","hasOwnProperty","call","apply","this","bar"],"mappings":"oOACA,IAAIA,EAEF,WAWE,OAVAA,EACEC,OAAOC,QACP,SAAUC,GACR,IAAK,IAAIC,EAAGC,EAAI,EAAGC,EAAIC,UAAUC,OAAQH,EAAIC,EAAGD,IAE9C,IAAK,IAAII,KADTL,EAAIG,UAAUF,GAERJ,OAAOS,UAAUC,eAAeC,KAAKR,EAAGK,KAAIN,EAAEM,GAAKL,EAAEK,IAE7D,OAAON,IAEKU,MAAMC,KAAMP,mBAGjBP,EAAS,GADd,CAAEe,IAAK"}
   `);
 });
+
+test("fails for source files containing top-level this", async () => {
+  let dir = await testdir({
+    "package.json": basicPkgJson(),
+    "src/index.js": js`
+                      export default this;
+                    `,
+  });
+
+  try {
+    await build(dir);
+  } catch (err) {
+    expect(err.message).toMatchInlineSnapshot(`
+      "🎁  pkg \\"src/index.js\\" used \`this\` keyword at the top level of an ES module. You can read more about this at https://rollupjs.org/guide/en/#error-this-is-undefined and fix this issue that has happened here:
+      🎁  pkg 
+      🎁  pkg 1: export default this;
+      🎁  pkg                   ^
+      🎁  pkg "
+    `);
+    return;
+  }
+  expect(true).toBe(false);
+});

--- a/packages/cli/src/build/__tests__/other.ts
+++ b/packages/cli/src/build/__tests__/other.ts
@@ -802,7 +802,7 @@ test("fails for source files containing top-level this", async () => {
       🎁  pkg
       🎁  pkg 1: export default this;
       🎁  pkg                   ^
-      🎁  pkg "
+      🎁  pkg"
     `);
     return;
   }

--- a/packages/cli/src/build/__tests__/other.ts
+++ b/packages/cli/src/build/__tests__/other.ts
@@ -799,7 +799,7 @@ test("fails for source files containing top-level this", async () => {
   } catch (err) {
     expect(err.message).toMatchInlineSnapshot(`
       "🎁  pkg \\"src/index.js\\" used \`this\` keyword at the top level of an ES module. You can read more about this at https://rollupjs.org/guide/en/#error-this-is-undefined and fix this issue that has happened here:
-      🎁  pkg 
+      🎁  pkg
       🎁  pkg 1: export default this;
       🎁  pkg                   ^
       🎁  pkg "

--- a/packages/cli/src/build/rollup.ts
+++ b/packages/cli/src/build/rollup.ts
@@ -85,9 +85,10 @@ export let getRollupConfig = (
         return;
       }
       switch (warning.code) {
+        case "CIRCULAR_DEPENDENCY":
         case "EMPTY_BUNDLE":
         case "EVAL":
-        case "CIRCULAR_DEPENDENCY":
+        case "THIS_IS_UNDEFINED":
         case "UNUSED_EXTERNAL_IMPORT": {
           break;
         }

--- a/packages/cli/src/build/rollup.ts
+++ b/packages/cli/src/build/rollup.ts
@@ -88,7 +88,6 @@ export let getRollupConfig = (
         case "CIRCULAR_DEPENDENCY":
         case "EMPTY_BUNDLE":
         case "EVAL":
-        case "THIS_IS_UNDEFINED":
         case "UNUSED_EXTERNAL_IMPORT": {
           break;
         }
@@ -105,6 +104,21 @@ export let getRollupConfig = (
             );
             return;
           }
+        }
+        case "THIS_IS_UNDEFINED": {
+          if (type === "umd") {
+            return;
+          }
+          warnings.push(
+            new FatalError(
+              `"${path.relative(
+                pkg.directory,
+                warning.loc!.file!
+              )}" used \`this\` keyword at the top level of an ES module. You can read more about this at ${warning.url!} and fix this issue that has happened here:\n\n${warning.frame!}\n`,
+              pkg.name
+            )
+          );
+          return;
         }
         default: {
           warnings.push(

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -19,7 +19,10 @@ export function format(
     util
       .format("", ...args)
       .split("\n")
-      .join("\n" + fullPrefix + " ")
+      .reduce((str, line) => {
+        const prefixed = `${str}\n${fullPrefix}`;
+        return line ? `${prefixed} ${line}` : prefixed;
+      })
   );
 }
 export function error(message: string, scope?: string) {

--- a/packages/cli/test-utils/index.ts
+++ b/packages/cli/test-utils/index.ts
@@ -262,7 +262,7 @@ export const typescriptFixture: Fixture = {
       // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
       // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
       // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-  
+
       /* Strict Type-Checking Options */
       "strict": true /* Enable all strict type-checking options. */,
       // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -272,13 +272,13 @@ export const typescriptFixture: Fixture = {
       // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
       // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
       // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-  
+
       /* Additional Checks */
       // "noUnusedLocals": true,                /* Report errors on unused locals. */
       // "noUnusedParameters": true,            /* Report errors on unused parameters. */
       // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
       // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-  
+
       /* Module Resolution Options */
       // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
       // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
@@ -289,13 +289,13 @@ export const typescriptFixture: Fixture = {
       // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
       "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
       // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-  
+
       /* Source Map Options */
       // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
       // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
       // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
       // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-  
+
       /* Experimental Options */
       // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
       // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
@@ -309,11 +309,11 @@ export const typescriptFixture: Fixture = {
                     import { SomeType } from "./another-thing";
                     export * from "./one-more-thing";
                     import * as path from "path";
-                    
+
                     export { path };
-                    
+
                     let thing: SomeType = "something";
-                    
+
                     export default thing;
                   `,
   "src/another-thing.ts": ts`
@@ -324,7 +324,7 @@ export const typescriptFixture: Fixture = {
                            `,
   "src/one-more-thing.d.ts": ts`
                                declare var obj: object;
-                               
+
                                export { obj };
                              `,
 };
@@ -398,10 +398,21 @@ export async function getFiles(dir: string, glob: string[] = ["**"]) {
   return newObj;
 }
 
-export const basicPkgJson = (options?: { module?: boolean }) => {
+export const basicPkgJson = (options?: {
+  module?: boolean;
+  dependencies?: Record<string, string>;
+  umdName?: string;
+}) => {
   return JSON.stringify({
     name: "pkg",
     main: "dist/pkg.cjs.js",
     module: options?.module ? "dist/pkg.esm.js" : undefined,
+    ...(options?.umdName && {
+      "umd:main": "dist/pkg.umd.min.js",
+      preconstruct: {
+        umdName: options.umdName,
+      },
+    }),
+    dependencies: options?.dependencies,
   });
 };

--- a/packages/eslint-plugin-format-js-tag/src/index.ts
+++ b/packages/eslint-plugin-format-js-tag/src/index.ts
@@ -15,6 +15,27 @@ const tags = {
   tsx: true,
 };
 
+const compareLines = (actual: string, expected: string): boolean => {
+  const actualLines = actual.split("\n");
+  const expectedLines = expected.split("\n");
+
+  if (actualLines.length !== expectedLines.length) {
+    return false;
+  }
+
+  for (let i = 0; i <= actualLines.length; i++) {
+    if (actualLines[i] === expectedLines[i]) {
+      continue;
+    }
+    if (/\S/.test(actualLines[i]) || /\S/.test(expectedLines[i])) {
+      return false;
+    }
+    // both contain just whitespaces, ignore a mismatch and continue
+  }
+
+  return true;
+};
+
 export const rules = {
   format: createRule<[], MessageId>({
     name: "format",
@@ -60,7 +81,7 @@ export const rules = {
                 .join("\n"); //+
             //   "\n" +
             //   "".padEnd(node.tag.loc.start.column);
-            if (formatted !== str) {
+            if (!compareLines(str, formatted)) {
               context.report({
                 messageId: "unformatted",
                 node: node.tag,

--- a/packages/eslint-plugin-format-js-tag/src/index.ts
+++ b/packages/eslint-plugin-format-js-tag/src/index.ts
@@ -15,27 +15,6 @@ const tags = {
   tsx: true,
 };
 
-const compareLines = (actual: string, expected: string): boolean => {
-  const actualLines = actual.split("\n");
-  const expectedLines = expected.split("\n");
-
-  if (actualLines.length !== expectedLines.length) {
-    return false;
-  }
-
-  for (let i = 0; i <= actualLines.length; i++) {
-    if (actualLines[i] === expectedLines[i]) {
-      continue;
-    }
-    if (/\S/.test(actualLines[i]) || /\S/.test(expectedLines[i])) {
-      return false;
-    }
-    // both contain just whitespaces, ignore a mismatch and continue
-  }
-
-  return true;
-};
-
 export const rules = {
   format: createRule<[], MessageId>({
     name: "format",
@@ -76,12 +55,15 @@ export const rules = {
                   if (i === lines.length - 1) {
                     return "".padEnd(node.tag.loc.start.column) + line;
                   }
+                  if (line === "") {
+                    return "";
+                  }
                   return indentation + line;
                 })
                 .join("\n"); //+
             //   "\n" +
             //   "".padEnd(node.tag.loc.start.column);
-            if (!compareLines(str, formatted)) {
+            if (formatted !== str) {
               context.report({
                 messageId: "unformatted",
                 node: node.tag,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6019,7 +6019,7 @@ fast-glob@^3.0.3, fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-glob@^3.2.2, fast-glob@^3.2.4:
+fast-glob@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==


### PR DESCRIPTION
Relates to https://github.com/preconstruct/preconstruct/issues/339