### PR TITLE
Respect `package.json#browser` when bundling dependencies for the UMD build

### DIFF
--- a/.changeset/large-pens-work.md
+++ b/.changeset/large-pens-work.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": minor
+---
+
+Respect `package.json#browser` when bundling dependencies for the UMD build.

--- a/packages/cli/src/build/rollup.ts
+++ b/packages/cli/src/build/rollup.ts
@@ -166,6 +166,7 @@ export let getRollupConfig = (
         }),
       resolve({
         extensions: EXTENSIONS,
+        browser: type === "umd",
         customResolveOptions: {
           moduleDirectory: type === "umd" ? "node_modules" : [],
         },


### PR DESCRIPTION
Relates to #339