### PR TITLE
Add keepDynamicImportAsDynamicImportInCommonJS experimental flag

### DIFF
--- a/.changeset/hip-steaks-swim.md
+++ b/.changeset/hip-steaks-swim.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Add `keepDynamicImportAsDynamicImportInCommonJS` experimental flag to allow importing Node ESM packages in Preconstruct packages

--- a/.changeset/hip-steaks-swim.md
+++ b/.changeset/hip-steaks-swim.md
@@ -2,4 +2,6 @@
 "@preconstruct/cli": patch
 ---
 
-Add `keepDynamicImportAsDynamicImportInCommonJS` experimental flag to allow importing Node ESM packages in Preconstruct packages
+Add `keepDynamicImportAsDynamicImportInCommonJS` experimental flag to allow importing Node ESM-only packages in Preconstruct packages. This can be used to ship a package that can be both imported and required and has a dependency that doesn't have a CommonJS distribution.
+
+Note that `import()` is asynchronous so it won't be possible to get access to such ESM-only dependency synchronously.

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -28,6 +28,7 @@ export class Project extends Item<{
     ___experimentalFlags_WILL_CHANGE_IN_PATCH: {
       logCompiledFiles?: JSONValue;
       typeScriptProxyFileWithImportEqualsRequireAndExportEquals?: JSONValue;
+      keepDynamicImportAsDynamicImportInCommonJS?: JSONValue;
     };
   };
 }> {
@@ -37,6 +38,7 @@ export class Project extends Item<{
     return {
       logCompiledFiles: !!config.logCompiledFiles,
       typeScriptProxyFileWithImportEqualsRequireAndExportEquals: !!config.typeScriptProxyFileWithImportEqualsRequireAndExportEquals,
+      keepDynamicImportAsDynamicImportInCommonJS: !!config.keepDynamicImportAsDynamicImportInCommonJS,
     };
   }
   get configPackages(): Array<string> {

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -98,6 +98,7 @@ export const FORMER_FLAGS_THAT_ARE_ENABLED_NOW = new Set<string>([
 export const EXPERIMENTAL_FLAGS = new Set([
   "logCompiledFiles",
   "typeScriptProxyFileWithImportEqualsRequireAndExportEquals",
+  "keepDynamicImportAsDynamicImportInCommonJS",
 ]);
 
 export function validateProject(project: Project, log = false) {


### PR DESCRIPTION
This is part 1 of Node ESM support in Preconstruct, solving the problem of "I want to ship a package that works from imports or requires but I want to depend on an ESM only package and I'm okay with only being able to get the dependency asynchronously"

cc @Andarist 