### PR TITLE
Add details to monorepo tutorial Babel install

### DIFF
--- a/site/src/pages/tutorials/monorepo.mdx
+++ b/site/src/pages/tutorials/monorepo.mdx
@@ -92,7 +92,7 @@ We'll also want to add Babel so that we can use modern features when writing our
 We're going to install `@babel/core` and `@babel/preset-env` and add it our Babel config.
 
 ```bash
-yarn add @babel/preset-env
+yarn add @babel/core @babel/preset-env
 ```
 
 `babel.config.js`

--- a/site/src/pages/tutorials/monorepo.mdx
+++ b/site/src/pages/tutorials/monorepo.mdx
@@ -103,6 +103,8 @@ module.exports = {
 };
 ```
 
+If you'd like to use TypeScript, read the [Building TypeScript packages guide](/guides/building-typescript-packages). You'll want to _add_ `@babel/preset-typescript` to the `presets` array.
+
 > Curious about why we're using a babel.config.js file here instead of a .babelrc file? Read the [Configuring Babel guide](/guides/configuring-babel)
 
 Now we can run `preconstruct build` to build our packages. 🎉

--- a/site/src/pages/tutorials/monorepo.mdx
+++ b/site/src/pages/tutorials/monorepo.mdx
@@ -92,7 +92,7 @@ We'll also want to add Babel so that we can use modern features when writing our
 We're going to install `@babel/core` and `@babel/preset-env` and add it our Babel config.
 
 ```bash
-yarn add @babel/core @babel/preset-env
+yarn add -W @babel/core @babel/preset-env
 ```
 
 `babel.config.js`


### PR DESCRIPTION
This PR adds a few extra details to `tutorials/monorepo.mdx` to increase clarity/reduce confusion:

- added `@babel/core` to the list of `yarn add` packages, since it's mentioned above but not included in the actual command
- added `-W` flag to `yarn add` command, to make it clear that these packages are being installed to the root `package.json`
- added a link to the "Building TypeScript packages" guide, with a note that `@babel/preset-typescript` should be _added_ to the `presets` list