### PR TITLE
Add "hook-loader.js" to package files list in @preconstruct/next

### DIFF
--- a/.changeset/lovely-buttons-film.md
+++ b/.changeset/lovely-buttons-film.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/next": patch
+---
+
+Add "hook-loader.js" to package files list so it exists on npm

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@preconstruct/next",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "A Next.js plugin to work with preconstruct repos",
   "files": [
     "index.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@preconstruct/next",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Next.js plugin to work with preconstruct repos",
   "files": [
-    "index.js"
+    "index.js",
+    "hook-loader.js"
   ],
   "repository": "https://github.com/preconstruct/preconstruct/tree/main/packages/next",
   "license": "MIT",


### PR DESCRIPTION
I am experiencing an issue during KeystoneJS Next setup, which come from this package.
```
❯ yarn dev
yarn run v1.22.10
$ keystone-next dev
✨ Starting Keystone
⭐️ Dev Server Ready on http://localhost:3000
✨ Generating graphQL schema
✨ Connecting to the database
✨ The database is already in sync with the Prisma schema.
✨ Generating Admin UI code
✨ Creating server
✨ Preparing GraphQL Server
✨ Preparing Admin UI Next.js app
🚨 There was an error initialising Keystone
Error: Cannot find module './hook-loader'
Require stack:
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@preconstruct/next/index.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/next-config/dist/admin-ui.cjs.dev.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/next-config/dist/admin-ui.cjs.js
- /Users/vzhyltsov/projects/units/apps/keystone/.keystone/admin/next.config.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/next/dist/next-server/server/config.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/next/dist/next-server/server/next-server.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/next/dist/server/next.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/system/dist/admin-ui.cjs.dev.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/system/dist/admin-ui.cjs.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/keystone/scripts/dist/keystone.cjs.dev.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/keystone/scripts/dist/keystone.cjs.js
- /Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/keystone/bin/cli.js
    at Function.call (internal/modules/cjs/loader.js:815:15)
    at Function.mod._resolveFilename (/Users/vzhyltsov/projects/units/apps/keystone/node_modules/next/build/webpack/require-hook.ts:63:26)
    at Function.resolve (internal/modules/cjs/helpers.js:80:19)
    at Object.<anonymous> (/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@preconstruct/next/index.js:6:28)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/next-config/dist/admin-ui.cjs.dev.js:7:24)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@preconstruct/next/index.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/next-config/dist/admin-ui.cjs.dev.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/next-config/dist/admin-ui.cjs.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/.keystone/admin/next.config.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/next/dist/next-server/server/config.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/next/dist/next-server/server/next-server.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/next/dist/server/next.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/system/dist/admin-ui.cjs.dev.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/admin-ui/system/dist/admin-ui.cjs.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/keystone/scripts/dist/keystone.cjs.dev.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/keystone/scripts/dist/keystone.cjs.js',
    '/Users/vzhyltsov/projects/units/apps/keystone/node_modules/@keystone-next/keystone/bin/cli.js'
  ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
I believe that lising `hook-loader.js` in package files should fix the problem