### PR TITLE
Document TypeScript compiler configuration

### DIFF
--- a/site/src/pages/errors.mdx
+++ b/site/src/pages/errors.mdx
@@ -24,4 +24,4 @@ Preconstruct requires that all entrypoints in a package have the same fields so 
 
 ## '{export-a}' is not exported by {module-a}, imported by {module-b}
 
-If you are building a TypeScript package, chances are you're re-exporting a type in a way that's not compatible with `@babel/preset-typescript`. See [Building TypeScript packages](/guides/building-typescript-packages) for more information.
+If you are building a TypeScript package, chances are you're re-exporting a type in a way that's not compatible with `@babel/preset-typescript`. See [Building TypeScript packages](/guides/building-typescript-packages) for more information. To fix it, you should use [type-only imports and exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)

--- a/site/src/pages/errors.mdx
+++ b/site/src/pages/errors.mdx
@@ -21,3 +21,7 @@ Preconstruct requires that all imports in a package must either packages that ar
 ## {entrypoint-name-a} has a {field-name} build but {entrypoint-name-b} does not have a {field-name} build. Entrypoints in a package must either all have a particular build type or all not have a particular build type.
 
 Preconstruct requires that all entrypoints in a package have the same fields so that it can guarantee that common modules between entrypoints will never be instantiated twice within an environment.
+
+## '{export-a}' is not exported by {module-a}, imported by {module-b}
+
+If you are building a TypeScript package, chances are you're re-exporting a type in a way that's not compatible with `@babel/preset-typescript`. See [Building TypeScript packages](/guides/building-typescript-packages) for more information.

--- a/site/src/pages/guides/building-typescript-packages.mdx
+++ b/site/src/pages/guides/building-typescript-packages.mdx
@@ -11,3 +11,20 @@ Preconstruct uses Babel to compile code so you have to [configure Babel](/guides
 ## Generating TypeScript declarations
 
 Preconstruct automatically generates TypeScript declarations for all entrypoints in a package. There's no work required to configure this other than having your entrypoint source file be a `.ts` or `.tsx` file and having a `tsconfig.json`.
+
+## Configuring TypeScript
+
+Because Preconstruct uses Babel to compile TypeScript packages, it is recommended to set the `isolatedModules` compiler option to ensure your TypeScript source can be built with Babel.
+
+In your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}
+```
+
+See the [TypeScript documentation on the `isolatedModules` option](https://www.typescriptlang.org/tsconfig#isolatedModules) and the [Babel documenation on TypeScript compiler options](https://babeljs.io/docs/en/babel-plugin-transform-typescript#typescript-compiler-options) for more information.
+


### PR DESCRIPTION
Document the `isolatedModules` TypeScript compiler/project option in the TypeScript guide. I also added an entry to the errors page, let me know if you think that makes sense.

I did come across some `An unhandled Rollup error occurred: *` when initially troubleshooting this so I could look into adding a friendlier error message if you think that'd be worthwhile.