### PR TITLE
feat: generate d.ts.map files

### DIFF
--- a/.changeset/calm-dryers-approve.md
+++ b/.changeset/calm-dryers-approve.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": minor
+---
+
+Added support for the `tsconfig.declarationMap` option. `preconstruct` now outputs both `d.ts` and `d.ts.map` files to `dist/declarations/src` when the option is enabled.

--- a/packages/cli/src/build/__tests__/basic.ts
+++ b/packages/cli/src/build/__tests__/basic.ts
@@ -101,6 +101,86 @@ test("typescript thing", async () => {
   await snapshotDirectory(path.join(tmpPath, "dist"), { files: "all" });
 });
 
+test("typescript declarationMap", async () => {
+  let dir = await testdir({
+    "package.json": JSON.stringify({
+      name: "typescript-declarationMap",
+      main: "dist/typescript-declarationMap.cjs.js",
+      module: "dist/typescript-declarationMap.esm.js",
+
+      dependencies: {
+        "@babel/runtime": "^7.8.7",
+      },
+
+      devDependencies: {
+        typescript: "^3.8.3",
+      },
+    }),
+    ".babelrc": JSON.stringify({
+      presets: [require.resolve("@babel/preset-typescript")],
+    }),
+    node_modules: {
+      kind: "symlink",
+      path: repoNodeModules,
+    },
+    "tsconfig.json": JSON.stringify(
+      {
+        compilerOptions: {
+          target: "esnext",
+          module: "esnext",
+          declarationMap: true,
+          jsx: "react",
+          isolatedModules: true,
+          strict: true,
+          moduleResolution: "node",
+          esModuleInterop: true,
+          noEmit: true,
+        },
+      },
+      null,
+      2
+    ),
+    "src/index.ts": ts`
+                      export const thing = "wow" as const;
+                    `,
+  });
+
+  await build(dir);
+  await expect(getDist(dir)).resolves.toMatchInlineSnapshot(`
+          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+          export declare const thing: "wow";
+          //# sourceMappingURL=index.d.ts.map
+          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts.map ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+          {"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,KAAK,OAAiB,CAAC"}
+          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/typescript-declarationMap.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+          export * from "./declarations/src/index";
+
+          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/typescript-declarationMap.cjs.dev.js, dist/typescript-declarationMap.cjs.prod.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+          'use strict';
+
+          Object.defineProperty(exports, '__esModule', { value: true });
+
+          const thing = "wow";
+
+          exports.thing = thing;
+
+          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/typescript-declarationMap.cjs.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+          'use strict';
+
+          if (process.env.NODE_ENV === "production") {
+            module.exports = require("./typescript-declarationMap.cjs.prod.js");
+          } else {
+            module.exports = require("./typescript-declarationMap.cjs.dev.js");
+          }
+
+          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/typescript-declarationMap.esm.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+          const thing = "wow";
+
+          export { thing };
+
+        `);
+});
+
 test("process.env.NODE_ENV reassignment", async () => {
   const dir = await testdir({
     "package.json": JSON.stringify({

--- a/packages/cli/src/build/__tests__/basic.ts
+++ b/packages/cli/src/build/__tests__/basic.ts
@@ -151,7 +151,7 @@ test("typescript declarationMap", async () => {
           export declare const thing: "wow";
           //# sourceMappingURL=index.d.ts.map
           ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts.map ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-          {"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,KAAK,OAAiB,CAAC"}
+          {"version":3,"file":"index.d.ts","sourceRoot":"../../../src","sources":["index.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,KAAK,OAAiB,CAAC"}
           ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/typescript-declarationMap.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
           export * from "./declarations/src/index";
 

--- a/packages/cli/src/rollup-plugins/typescript-declarations/create-generator.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/create-generator.ts
@@ -6,6 +6,18 @@ import { FatalError } from "../../errors";
 import { createLanguageServiceHostClass } from "./language-service-host";
 import normalizePath from "normalize-path";
 
+interface DeclarationFile {
+  name: string;
+  content: string;
+}
+
+interface EmittedDeclarationOutput {
+  /** The emitted d.ts types file. */
+  types: DeclarationFile;
+  /** The emitted d.ts.map declaration map file. */
+  map?: DeclarationFile;
+}
+
 type Typescript = typeof import("typescript");
 
 let unsafeRequire = require;
@@ -82,9 +94,7 @@ export async function createDeclarationCreator(
   pkgName: string
 ): Promise<{
   getDeps: (entrypoints: Array<string>) => Set<string>;
-  getDeclarationFiles: (
-    filename: string
-  ) => Promise<{ name: string; content: string }[]>;
+  getDeclarationFiles: (filename: string) => Promise<EmittedDeclarationOutput>;
 }> {
   let typescript: Typescript;
   try {
@@ -180,26 +190,42 @@ export async function createDeclarationCreator(
     },
     getDeclarationFiles: async (
       filename: string
-    ): Promise<{ name: string; content: string }[]> => {
+    ): Promise<EmittedDeclarationOutput> => {
       if (filename.endsWith(".d.ts")) {
-        return [
-          {
+        return {
+          types: {
             name: filename.replace(
               normalizedDirname,
               normalizePath(path.join(dirname, "dist", "declarations"))
             ),
             content: await fs.readFile(filename, "utf8"),
           },
-        ];
+        };
       }
       let output = service.getEmitOutput(filename, true, true);
-      return output.outputFiles.map(({ name, text }) => ({
-        name: name.replace(
-          normalizedDirname,
-          normalizePath(path.join(dirname, "dist", "declarations"))
-        ),
-        content: text,
-      }));
+      return output.outputFiles.reduce((emitted, { name, text }) => {
+        if (name.endsWith(".d.ts")) {
+          emitted.types = {
+            name: name.replace(
+              normalizedDirname,
+              normalizePath(path.join(dirname, "dist", "declarations"))
+            ),
+            content: text,
+          };
+        }
+
+        if (name.endsWith(".d.ts.map")) {
+          emitted.map = {
+            name: name.replace(
+              normalizedDirname,
+              normalizePath(path.join(dirname, "dist", "declarations"))
+            ),
+            content: text,
+          };
+        }
+
+        return emitted;
+      }, {} as EmittedDeclarationOutput);
     },
   };
 }

--- a/packages/cli/src/rollup-plugins/typescript-declarations/index.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/index.ts
@@ -32,8 +32,8 @@ export default function typescriptDeclarations(pkg: Package): Plugin {
           });
 
           if (map) {
-            const sourceRoot = path.dirname(
-              path.relative(path.dirname(map.name), normalizePath(dep))
+            const sourceRoot = normalizePath(
+              path.dirname(path.relative(path.dirname(map.name), dep))
             );
             const source = overwriteDeclarationMapSourceRoot(
               map.content,

--- a/packages/cli/src/rollup-plugins/typescript-declarations/index.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/index.ts
@@ -22,12 +22,14 @@ export default function typescriptDeclarations(pkg: Package): Plugin {
       let deps = creator.getDeps(pkg.entrypoints.map((x) => x.source));
       await Promise.all(
         [...deps].map(async (dep) => {
-          let { name, content } = await creator.getDeclarationFile(dep);
-          srcFilenameToDtsFilenameMap.set(normalizePath(dep), name);
-          this.emitFile({
-            type: "asset",
-            fileName: path.relative(opts.dir!, name),
-            source: content,
+          let files = await creator.getDeclarationFiles(dep);
+          files.forEach(({ name, content }) => {
+            srcFilenameToDtsFilenameMap.set(normalizePath(dep), name);
+            this.emitFile({
+              type: "asset",
+              fileName: path.relative(opts.dir!, name),
+              source: content,
+            });
           });
         })
       );

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -202,6 +202,15 @@ export function tsTemplate(hasDefaultExport: boolean, relativePath: string) {
   }\n`;
 }
 
+export function overwriteDeclarationMapSourceRoot(
+  content: string,
+  actualSourceRoot: string
+): string {
+  const src = JSON.parse(content);
+  src.sourceRoot = actualSourceRoot;
+  return JSON.stringify(src);
+}
+
 export type JSONValue =
   | string
   | number

--- a/packages/cli/test-utils/index.ts
+++ b/packages/cli/test-utils/index.ts
@@ -395,7 +395,7 @@ async function readNormalizedFile(filePath: string): Promise<string> {
   let content = await fs.readFile(filePath, "utf8");
   // to normalise windows line endings
   content = content.replace(/\r\n/g, "\n");
-  if (/\.map$/.test(filePath)) {
+  if (/(?<!(\.d\.ts))\.map$/.test(filePath)) {
     const sourceMap = JSON.parse(content);
     sourceMap.sourcesContent = sourceMap.sourcesContent.map((source: string) =>
       source.replace(/\r\n/g, "\n")


### PR DESCRIPTION
This PR makes a change to handle `d.ts.map` files generated when the `tsconfig.declarationMap` option is enabled.

When this option is enabled, `LanguageService.getEmitOutput` outputs an array of the `d.ts.map` and `d.ts` files and their output, so I changed `getDeclarationFile` to `getDeclarationFiles`, and modified `generateBundle` to map over the files returned from it.

I guess this could technically be considered a bug since only the `d.ts.map` files are outputted currently, but feature sounds nicer :P 