### PR TITLE
fix logger receiveing `object` type `message`

### DIFF
--- a/.changeset/strong-grapes-perform.md
+++ b/.changeset/strong-grapes-perform.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Fixed logger failing when an unexpected type is received

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -12,7 +12,7 @@ export function format(
     none: "",
   }[messageType];
   let fullPrefix = "🎁" + prefix + (scope ? " " + chalk.cyan(scope) : "");
-  return message
+  return String(message)
     .split("\n")
     .map((line) => {
       if (!line.trim()) {


### PR DESCRIPTION
I encountered the error `TypeError: message.split is not a function` when using jsx without having `@babel/preset-react` defined.

It looks to me that `message` can be an `object` and casting it to string solved the issue for me.
