### PR TITLE
Support NextJS 12.0.0 

### DIFF
--- a/.changeset/famous-wasps-shave.md
+++ b/.changeset/famous-wasps-shave.md
@@ -1,0 +1,10 @@
+---
+"@preconstruct/next": patch
+---
+
+Fixed support for Next.js 12. Note that in Next.js 11 and 12, Next will not read a Babel config from outside of the directory that the Next.js site is in. If you need it to to read your babel config, you will need to do something like this:
+
+```js
+// site/babel.config.js
+module.exports = require("../babel.config");
+```

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -19,7 +19,7 @@ module.exports = (nextConfig = {}) => {
         delete rule.include;
       }
       if (rule.oneOf) {
-        rule.oneOf.forEach(foundRule)
+        rule.oneOf.forEach(foundRule);
       }
     };
 

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -8,7 +8,8 @@ module.exports = (nextConfig = {}) => {
   nextConfig.webpack = (webpackConfig, options) => {
     let hasFoundRule = false;
     options.defaultLoaders.babel.options.rootMode = "upward-optional";
-    webpackConfig.module.rules.forEach((rule) => {
+
+    const foundRule = (rule) => {
       if (
         rule.use === options.defaultLoaders.babel ||
         (Array.isArray(rule.use) &&
@@ -17,7 +18,17 @@ module.exports = (nextConfig = {}) => {
         hasFoundRule = true;
         delete rule.include;
       }
-    });
+    };
+
+    // Look at top level rules
+    webpackConfig.module.rules.forEach(foundRule);
+
+    // Look at rules nested under oneOf
+    const oneOfRule = webpackConfig.module.rules.find(rule => !!rule.oneOf);
+    const rules = oneOfRule ? oneOfRule.oneOf : [];
+
+    rules.forEach(foundRule);
+
     if (!hasFoundRule) {
       throw new Error(
         "If you see this error, please open an issue with your Next.js version and @preconstruct/next version. The Next Babel loader could not be found"

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -18,16 +18,13 @@ module.exports = (nextConfig = {}) => {
         hasFoundRule = true;
         delete rule.include;
       }
+      if (rule.oneOf) {
+        rule.oneOf.forEach(foundRule)
+      }
     };
 
     // Look at top level rules
     webpackConfig.module.rules.forEach(foundRule);
-
-    // Look at rules nested under oneOf
-    const oneOfRule = webpackConfig.module.rules.find(rule => !!rule.oneOf);
-    const rules = oneOfRule ? oneOfRule.oneOf : [];
-
-    rules.forEach(foundRule);
 
     if (!hasFoundRule) {
       throw new Error(


### PR DESCRIPTION
### Overview

NextJS 12.0.0 was released, officially moving NextJS away from Babel in favour of SWC.

This is an impactful change that probably requires more consideration than what I'm proposing here, however I'm aiming to do the bare minimum as a first step.

This PR aims to:

- Support existing NextJS versions by keeping the current webpack config alterations intact.
- Support Next 12 by additionally looking for babel rules inside of `oneOf` statements in the webpack rules set. 

### Open Questions

**SWC vs Babel** 

Next 12 will use **swc** by default. If it detects a babel configuration in your project, it'll revert back to using babel only.

This PR should tell Next's babel loaders to resolve our root level babel config, but this may not trigger Next's babel detection leaving us in a situation where we have correct Babel config, **but babel isn't used at all.**

Are there bigger implications here than what this PR can solve? Is Preconstruct effectively no longer compatible with Next? Or is it compatible, but we don't have the safety net of shared babel config for consistency? What limitations/dead ends can we foresee?

**Resiliency** 

This PR doesn't recursively look for `oneOf` rule sets in webpack and assumes they are only top level and that there's only one. We could be more recursive, but the current plugin is quite literal so I've kept it as such. 

### Related Issues 

Closes #419