### PR TITLE
Prevent URL from going to blank page

### DIFF
--- a/site/src/pages/tutorials/monorepo.mdx
+++ b/site/src/pages/tutorials/monorepo.mdx
@@ -62,7 +62,7 @@ Preconstruct has asked us some slightly different questions since it's detected 
 
 ### Setting up `preconstruct dev`
 
-`preconstruct dev` is a command in Preconstruct that lets you import your packages without having to build them every time you make a change or alias the dist files to source files in another tool like webpack, see the [Using Preconstruct dev in a monorepo guide](/guides/using-Preconstruct-dev-in-a-monorepo) for more info.
+`preconstruct dev` is a command in Preconstruct that lets you import your packages without having to build them every time you make a change or alias the dist files to source files in another tool like webpack, see the [Using Preconstruct dev in a monorepo guide](/guides/using-preconstruct-dev-in-a-monorepo) for more info.
 
 We're going to add it to a postinstall script so that yarn will run it after packages are installed. Our package.json will now look like this.
 


### PR DESCRIPTION
Small typo that I found while reading the documentation. 

Go to https://preconstruct.tools/tutorials/monorepo and click the "Using Preconstruct dev in a monorepo guide" link to see it open blank page.

