### PR TITLE
Limit `fast-glob` version range because of issue

### DIFF
--- a/.changeset/proud-stingrays-remain.md
+++ b/.changeset/proud-stingrays-remain.md
@@ -1,0 +1,7 @@
+---
+"@preconstruct/cli": patch
+---
+
+Limit fast-glob version range because of issue
+fast-glob versions after 3.2.7 have an issue https://github.com/mrmlnc/fast-glob/issues/351
+So it's good to temporary limit the version as workaround, until that issue is fixed.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "enquirer": "^2.3.6",
     "estree-walker": "^2.0.1",
     "fast-deep-equal": "^2.0.1",
-    "fast-glob": "^3.2.4",
+    "fast-glob": "^3.2.4 && <= 3.2.7",
     "fs-extra": "^9.0.1",
     "is-ci": "^2.0.0",
     "is-reference": "^1.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "enquirer": "^2.3.6",
     "estree-walker": "^2.0.1",
     "fast-deep-equal": "^2.0.1",
-    "fast-glob": "^3.2.4 && <= 3.2.7",
+    "fast-glob": "3.2.4-3.2.7",
     "fs-extra": "^9.0.1",
     "is-ci": "^2.0.0",
     "is-reference": "^1.2.1",


### PR DESCRIPTION
`fast-glob` versions after 3.2.7 has an issue https://github.com/mrmlnc/fast-glob/issues/351
So it's good to temporary limit the version as workaround, until that issue is fixed.