### PR TITLE
Bump `fast-glob` to `^3.2.11` to fix braces issue

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "enquirer": "^2.3.6",
     "estree-walker": "^2.0.1",
     "fast-deep-equal": "^2.0.1",
-    "fast-glob": "^3.2.4",
+    "fast-glob": "^3.2.11",
     "fs-extra": "^9.0.1",
     "is-ci": "^2.0.0",
     "is-reference": "^1.2.1",


### PR DESCRIPTION
Issue https://github.com/mrmlnc/fast-glob/issues/351 is fixed in recent fast-glob 3.2.11 release.
Resolves https://github.com/preconstruct/preconstruct/issues/439