### PR TITLE
Fix babel-eslint error when running `yarn start:site`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,6 @@
     "@types/source-map-support": "^0.5.0",
     "@types/terser": "^3.12.0",
     "@typescript-eslint/parser": "^5.4.0",
-    "babel-core": "^7.0.0-bridge.0",
-    "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-plugin-macros": "^2.8.0",
     "codecov": "^3.6.1",

--- a/site/src/gatsby-theme-sidebar/root.js
+++ b/site/src/gatsby-theme-sidebar/root.js
@@ -45,14 +45,16 @@ const MenuButton = (props) => (
   />
 );
 
-const Title = (props) => (
+const Title = ({ children, ...props }) => (
   <h1
     {...props}
     css={{
       margin: 0,
       fontSize: 16,
     }}
-  />
+  >
+    {children}
+  </h1>
 );
 
 const hamburger = (
@@ -68,11 +70,19 @@ const hamburger = (
 );
 
 let components = {
-  a: ({ href, ...props }) => {
+  a: ({ href, children, ...props }) => {
     if (href.startsWith("http")) {
-      return <a href={href} {...props} />;
+      return (
+        <a href={href} {...props}>
+          {children}
+        </a>
+      );
     }
-    return <Link to={href} {...props} />;
+    return (
+      <Link to={href} {...props}>
+        {children}
+      </Link>
+    );
   },
   blockquote: (props) => {
     return (
@@ -164,6 +174,7 @@ export default ({
               fontSize: 24,
               marginRight: 8,
             }}
+            aria-hidden
           >
             🎁
           </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,12 +3030,12 @@ babel-code-frame@6.26.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
+babel-core@7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
-babel-eslint@^10.0.3, babel-eslint@^10.1.0:
+babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
   integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==


### PR DESCRIPTION
Closes #456. Also fixed some ESLint warnings in `gatsby-theme-sidebar/root.js`.