### PR TITLE
Remove typeScriptProxyFileWithImportEqualsRequireAndExportEquals experimental flag

### DIFF
--- a/.changeset/neat-horses-worry.md
+++ b/.changeset/neat-horses-worry.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Removed `typeScriptProxyFileWithImportEqualsRequireAndExportEquals` experimental flag.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,8 +47,3 @@ There are a number of tasks that become easier with preconstruct that lie slight
 - [Kye Hohenberger](https://github.com/tkh44) for thinking of the name preconstruct
 - Too many awesome people to name at [Thinkmill](https://thinkmill.com.au) who have given so much great feedback to make Preconstruct better and Thinkmill for sponsoring the development of Preconstruct 💝
 - all the people who wrote all the dependencies for this project!
-
-# Things that review would be good on
-
-- https://medium.com/@mitchell_hamilton/introducing-preconstruct-26996f23de2a
--

--- a/packages/cli/src/__tests__/dev.ts
+++ b/packages/cli/src/__tests__/dev.ts
@@ -282,31 +282,6 @@ test("typescript", async () => {
   ).toMatchSnapshot();
 });
 
-test("typescript with typeScriptProxyFileWithImportEqualsRequireAndExportEquals", async () => {
-  let tmpPath = await testdir({
-    ...typescriptFixture,
-    "package.json": JSON.stringify({
-      ...JSON.parse(typescriptFixture["package.json"]),
-      preconstruct: {
-        ___experimentalFlags_WILL_CHANGE_IN_PATCH: {
-          typeScriptProxyFileWithImportEqualsRequireAndExportEquals: true,
-        },
-      },
-    }),
-  });
-
-  await dev(tmpPath);
-
-  await expect(
-    fs.readFile(path.join(tmpPath, "dist", "typescript.cjs.d.ts"), "utf8")
-  ).resolves.toMatchInlineSnapshot(`
-    "import mod = require("../src/index");
-
-    export = mod;
-    "
-  `);
-});
-
 test("exports field with worker condition", async () => {
   let tmpPath = realFs.realpathSync.native(
     await testdir({

--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -93,18 +93,12 @@ export async function writeDevTSFile(
     .join(entrypoint.directory, validFieldsForEntrypoint.main(entrypoint))
     .replace(/\.js$/, ".d.ts");
 
-  let output = await (entrypoint.package.project.experimentalFlags
-    .typeScriptProxyFileWithImportEqualsRequireAndExportEquals
-    ? `import mod = require(${JSON.stringify(
-        normalizePath(
-          path
-            .relative(path.dirname(cjsDistPath), entrypoint.source)
-            .replace(/\.tsx?$/, "")
-        )
-      )});\n\nexport = mod;\n`
-    : entrypointHasDefaultExport(entrypoint, entrypointSourceContent).then(
-        (hasDefaultExport) =>
-          `// are you seeing an error that a default export doesn't exist but your source file has a default export?
+  let output = await entrypointHasDefaultExport(
+    entrypoint,
+    entrypointSourceContent
+  ).then(
+    (hasDefaultExport) =>
+      `// are you seeing an error that a default export doesn't exist but your source file has a default export?
 // you should run \`yarn\` or \`yarn preconstruct dev\` if preconstruct dev isn't in your postinstall hook
 
 // curious why you need to?
@@ -115,15 +109,15 @@ export async function writeDevTSFile(
 // to check for a default export and re-export it if it exists
 // it's not ideal, but it works pretty well ¯\\_(ツ)_/¯
 ` +
-          tsTemplate(
-            hasDefaultExport,
-            normalizePath(
-              path
-                .relative(path.dirname(cjsDistPath), entrypoint.source)
-                .replace(/\.tsx?$/, "")
-            )
-          )
-      ));
+      tsTemplate(
+        hasDefaultExport,
+        normalizePath(
+          path
+            .relative(path.dirname(cjsDistPath), entrypoint.source)
+            .replace(/\.tsx?$/, "")
+        )
+      )
+  );
 
   await fs.outputFile(cjsDistPath, output);
 }

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -28,7 +28,6 @@ export class Project extends Item<{
     exports?: JSONValue;
     ___experimentalFlags_WILL_CHANGE_IN_PATCH: {
       logCompiledFiles?: JSONValue;
-      typeScriptProxyFileWithImportEqualsRequireAndExportEquals?: JSONValue;
       keepDynamicImportAsDynamicImportInCommonJS?: JSONValue;
     };
   };
@@ -38,7 +37,6 @@ export class Project extends Item<{
       this.json.preconstruct.___experimentalFlags_WILL_CHANGE_IN_PATCH || {};
     return {
       logCompiledFiles: !!config.logCompiledFiles,
-      typeScriptProxyFileWithImportEqualsRequireAndExportEquals: !!config.typeScriptProxyFileWithImportEqualsRequireAndExportEquals,
       keepDynamicImportAsDynamicImportInCommonJS: !!config.keepDynamicImportAsDynamicImportInCommonJS,
     };
   }

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -130,7 +130,6 @@ export const FORMER_FLAGS_THAT_ARE_ENABLED_NOW = new Set<string>([
 
 export const EXPERIMENTAL_FLAGS = new Set([
   "logCompiledFiles",
-  "typeScriptProxyFileWithImportEqualsRequireAndExportEquals",
   "keepDynamicImportAsDynamicImportInCommonJS",
 ]);
 


### PR DESCRIPTION
This solution to needing to re-run `preconstruct dev` after adding/removing a default export to an entrypoint didn't work out because [`export =` can't be used with `export *`](https://www.typescriptlang.org/play#code/CYUwxgNghgTiAEBbA9sArhBAiKX4G8AoeE+EADwAdkYAXeMZAOwGd6p4BeeARgG5CAX0KhIsBCnSZ4WAEZ4iJAJaJqdJKi7w4ARzRK4AChxYAlAJIU19bpIHCR4aHA1TsYBcVJWa9AFTwAGYwyIgy8kJAA).

