### PR TITLE
Add experimental flag for only generating declarations that are actually used in other declarations

### DIFF
--- a/.changeset/fuzzy-flies-rest.md
+++ b/.changeset/fuzzy-flies-rest.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Add `onlyEmitUsedTypeScriptDeclarations` experimental flag

--- a/packages/cli/src/build/__tests__/basic.ts
+++ b/packages/cli/src/build/__tests__/basic.ts
@@ -10,7 +10,6 @@ import {
   ts,
   repoNodeModules,
   js,
-  typescriptFixture,
 } from "../../../test-utils";
 import { BatchError } from "../../errors";
 import stripAnsi from "strip-ansi";
@@ -1316,72 +1315,6 @@ test(".d.ts file with default export", async () => {
     const a = true;
 
     export { a, a as default };
-
-  `);
-});
-
-test("circular dependency typescript", async () => {
-  let dir = await testdir({
-    "package.json": JSON.stringify({
-      name: "@scope/test",
-      main: "dist/scope-test.cjs.js",
-      module: "dist/scope-test.esm.js",
-    }),
-    "tsconfig.json": typescriptFixture["tsconfig.json"],
-    node_modules: typescriptFixture.node_modules,
-    "src/index.ts": ts`
-      export { blah } from "./a";
-      export function thing() {}
-    `,
-    "src/a.ts": ts`
-      export { thing } from "./index";
-      export function blah() {}
-    `,
-  });
-  await build(dir);
-  expect(await getDist(dir)).toMatchInlineSnapshot(`
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/a.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    export { thing } from "./index";
-    export declare function blah(): void;
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    export { blah } from "./a";
-    export declare function thing(): void;
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    export * from "./declarations/src/index";
-    //# sourceMappingURL=scope-test.cjs.d.ts.map
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts.map ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    {"version":3,"file":"scope-test.cjs.d.ts","sourceRoot":"","sources":["./declarations/src/index.d.ts"],"names":[],"mappings":"AAAA"}
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.dev.js, dist/scope-test.cjs.prod.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    'use strict';
-
-    Object.defineProperty(exports, '__esModule', { value: true });
-
-    function blah() {}
-
-    function thing() {}
-
-    exports.blah = blah;
-    exports.thing = thing;
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    'use strict';
-
-    if (process.env.NODE_ENV === "production") {
-      module.exports = require("./scope-test.cjs.prod.js");
-    } else {
-      module.exports = require("./scope-test.cjs.dev.js");
-    }
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.esm.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    function blah() {}
-
-    function thing() {}
-
-    export { blah, thing };
 
   `);
 });

--- a/packages/cli/src/build/__tests__/declarations.ts
+++ b/packages/cli/src/build/__tests__/declarations.ts
@@ -1,0 +1,244 @@
+import build from "..";
+import {
+  testdir,
+  typescriptFixture,
+  getDist,
+  getFiles,
+  ts,
+} from "../../../test-utils";
+
+test("circular dependency typescript", async () => {
+  let dir = await testdir({
+    "package.json": JSON.stringify({
+      name: "@scope/test",
+      main: "dist/scope-test.cjs.js",
+      module: "dist/scope-test.esm.js",
+    }),
+    "tsconfig.json": typescriptFixture["tsconfig.json"],
+    node_modules: typescriptFixture.node_modules,
+    "src/index.ts": ts`
+      export { blah } from "./a";
+      export function thing() {}
+    `,
+    "src/a.ts": ts`
+      export { thing } from "./index";
+      export function blah() {}
+    `,
+  });
+  await build(dir);
+  expect(await getDist(dir)).toMatchInlineSnapshot(`
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/a.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export { thing } from "./index";
+    export declare function blah(): void;
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export { blah } from "./a";
+    export declare function thing(): void;
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export * from "./declarations/src/index";
+    //# sourceMappingURL=scope-test.cjs.d.ts.map
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts.map ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    {"version":3,"file":"scope-test.cjs.d.ts","sourceRoot":"","sources":["./declarations/src/index.d.ts"],"names":[],"mappings":"AAAA"}
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.dev.js, dist/scope-test.cjs.prod.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    'use strict';
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+    function blah() {}
+
+    function thing() {}
+
+    exports.blah = blah;
+    exports.thing = thing;
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    'use strict';
+
+    if (process.env.NODE_ENV === "production") {
+      module.exports = require("./scope-test.cjs.prod.js");
+    } else {
+      module.exports = require("./scope-test.cjs.dev.js");
+    }
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.esm.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    function blah() {}
+
+    function thing() {}
+
+    export { blah, thing };
+
+  `);
+});
+
+const onlyEmitUsedDeclsBasic = {
+  "package.json": JSON.stringify({
+    name: "@scope/test",
+    main: "dist/scope-test.cjs.js",
+    module: "dist/scope-test.esm.js",
+    preconstruct: {
+      ___experimentalFlags_WILL_CHANGE_IN_PATCH: {
+        onlyEmitUsedTypeScriptDeclarations: true,
+      },
+    },
+  }),
+  "tsconfig.json": typescriptFixture["tsconfig.json"],
+  node_modules: typescriptFixture.node_modules,
+  ".babelrc": JSON.stringify({
+    presets: [require.resolve("@babel/preset-typescript")],
+  }),
+};
+
+test("onlyEmitUsedTypeScriptDeclarations", async () => {
+  let dir = await testdir({
+    ...onlyEmitUsedDeclsBasic,
+    "src/index.ts": ts`
+      import { A } from "./other";
+      export function thing(): A {
+        return { something: true };
+      }
+    `,
+    "src/other.ts": ts`
+      export type A = { something: true };
+    `,
+  });
+  await build(dir);
+  expect(await getFiles(dir, ["dist/**/*.d.ts"])).toMatchInlineSnapshot(`
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    import { A } from "./other";
+    export declare function thing(): A;
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/other.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export type A = {
+        something: true;
+    };
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export * from "./declarations/src/index";
+    //# sourceMappingURL=scope-test.cjs.d.ts.map
+
+  `);
+});
+
+test("onlyEmitUsedTypeScriptDeclarations with unused", async () => {
+  let dir = await testdir({
+    ...onlyEmitUsedDeclsBasic,
+    "src/index.ts": ts`
+      import { A } from "./other";
+
+      function a(): A {
+        return { something: true };
+      }
+
+      console.log(a());
+      export function thing() {}
+    `,
+    "src/other.ts": ts`
+      export type A = { something: true };
+    `,
+  });
+  await build(dir);
+  expect(await getFiles(dir, ["dist/**/*.d.ts"])).toMatchInlineSnapshot(`
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export declare function thing(): void;
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export * from "./declarations/src/index";
+    //# sourceMappingURL=scope-test.cjs.d.ts.map
+
+  `);
+});
+
+test("onlyEmitUsedTypeScriptDeclarations with export from", async () => {
+  let dir = await testdir({
+    ...onlyEmitUsedDeclsBasic,
+    "src/index.ts": ts`
+      export type { A } from "./other";
+    `,
+    "src/other.ts": ts`
+      export type A = { something: true };
+    `,
+  });
+  await build(dir);
+  expect(await getFiles(dir, ["dist/**/*.d.ts"])).toMatchInlineSnapshot(`
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export type { A } from "./other";
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/other.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export type A = {
+        something: true;
+    };
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export * from "./declarations/src/index";
+    //# sourceMappingURL=scope-test.cjs.d.ts.map
+
+  `);
+});
+
+test("onlyEmitUsedTypeScriptDeclarations with inline import type", async () => {
+  let dir = await testdir({
+    ...onlyEmitUsedDeclsBasic,
+    "src/index.ts": ts`
+      export function a(): import("./other").A {
+        return { something: true };
+      }
+    `,
+    "src/other.ts": ts`
+      export type A = { something: true };
+    `,
+  });
+  await build(dir);
+  expect(await getFiles(dir, ["dist/**/*.d.ts"])).toMatchInlineSnapshot(`
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export declare function a(): import("./other").A;
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/other.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export type A = {
+        something: true;
+    };
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export * from "./declarations/src/index";
+    //# sourceMappingURL=scope-test.cjs.d.ts.map
+
+  `);
+});
+
+test("onlyEmitUsedTypeScriptDeclarations with import x = require('')", async () => {
+  let dir = await testdir({
+    ...onlyEmitUsedDeclsBasic,
+    "src/index.ts": ts`
+      declare namespace something {
+        export import x = require("./other");
+      }
+      export function a(): something.x.A {
+        return { something: true };
+      }
+    `,
+    "src/other.ts": ts`
+      export type A = { something: true };
+    `,
+  });
+  await build(dir);
+  expect(await getFiles(dir, ["dist/**/*.d.ts"])).toMatchInlineSnapshot(`
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/index.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    declare namespace something {
+        export import x = require("./other");
+    }
+    export declare function a(): something.x.A;
+    export {};
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/declarations/src/other.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export type A = {
+        something: true;
+    };
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ dist/scope-test.cjs.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    export * from "./declarations/src/index";
+    //# sourceMappingURL=scope-test.cjs.d.ts.map
+
+  `);
+});

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -29,6 +29,7 @@ export class Project extends Item<{
     ___experimentalFlags_WILL_CHANGE_IN_PATCH: {
       logCompiledFiles?: JSONValue;
       keepDynamicImportAsDynamicImportInCommonJS?: JSONValue;
+      onlyEmitUsedTypeScriptDeclarations?: JSONValue;
     };
   };
 }> {
@@ -38,6 +39,7 @@ export class Project extends Item<{
     return {
       logCompiledFiles: !!config.logCompiledFiles,
       keepDynamicImportAsDynamicImportInCommonJS: !!config.keepDynamicImportAsDynamicImportInCommonJS,
+      onlyEmitUsedTypeScriptDeclarations: !!config.onlyEmitUsedTypeScriptDeclarations,
     };
   }
   get configPackages(): Array<string> {

--- a/packages/cli/src/rollup-plugins/typescript-declarations/common.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/common.ts
@@ -137,7 +137,8 @@ export const getDeclarationsForFile = async (
   program: import("typescript").Program,
   normalizedPkgDir: string,
   projectDir: string,
-  diagnosticsHost: import("typescript").FormatDiagnosticsHost
+  diagnosticsHost: import("typescript").FormatDiagnosticsHost,
+  transformers?: import("typescript").CustomTransformers
 ): Promise<EmittedDeclarationOutput> => {
   if (filename.endsWith(".d.ts")) {
     return {
@@ -186,7 +187,8 @@ export const getDeclarationsForFile = async (
       }
     },
     undefined,
-    true
+    true,
+    transformers
   );
 
   if (!emitted.types || diagnostics.length) {

--- a/packages/cli/src/rollup-plugins/typescript-declarations/get-declarations.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/get-declarations.ts
@@ -1,110 +1,64 @@
-import path from "path";
 import { FatalError } from "../../errors";
-import normalizePath from "normalize-path";
 import {
   EmittedDeclarationOutput,
   getDeclarationsForFile,
   getDiagnosticsHost,
-  getProgram,
-  loadTypeScript,
+  TS,
 } from "./common";
+import { Program, ResolvedModuleFull } from "typescript";
 
 export async function getDeclarations(
-  dirname: string,
-  pkgName: string,
+  typescript: TS,
+  program: Program,
+  normalizedPkgDir: string,
   projectDir: string,
-  entrypoints: string[]
-): Promise<{
-  entrypointSourceToTypeScriptSource: ReadonlyMap<string, string>;
-  declarations: EmittedDeclarationOutput[];
-}> {
-  const typescript = loadTypeScript(dirname, projectDir, pkgName);
+  pkgName: string,
+  resolveModuleName: (
+    moduleName: string,
+    containingFile: string
+  ) => ResolvedModuleFull | undefined,
+  resolvedEntrypointSources: string[]
+): Promise<EmittedDeclarationOutput[]> {
+  let allDeps = new Set(resolvedEntrypointSources);
 
-  const { program, options } = await getProgram(dirname, pkgName, typescript);
-  let moduleResolutionCache = typescript.createModuleResolutionCache(
-    dirname,
-    (x) => x,
-    options
-  );
-  let normalizedDirname = normalizePath(dirname);
-
-  // these will be distinct when using .d.ts files
-  const entrypointSourceToTypeScriptSource: ReadonlyMap<
-    string,
-    string
-  > = new Map(
-    entrypoints.map((x) => {
-      let { resolvedModule } = typescript.resolveModuleName(
-        path.join(path.dirname(x), path.basename(x, path.extname(x))),
-        dirname,
-        options,
-        typescript.sys,
-        moduleResolutionCache
+  for (let dep of allDeps) {
+    let sourceFile = program.getSourceFile(dep);
+    if (!sourceFile) {
+      throw new FatalError(
+        `Could not generate type declarations because ${dep} is not in a TypeScript project. Make sure this file is included in your tsconfig.`,
+        pkgName
       );
-      if (!resolvedModule) {
-        throw new Error(
-          "This is an internal error, please open an issue if you see this: ts could not resolve module"
-        );
+    }
+    for (let { text } of (sourceFile as any).imports) {
+      let resolvedModule = resolveModuleName(text, dep);
+      if (
+        resolvedModule &&
+        !allDeps.has(resolvedModule.resolvedFileName) &&
+        !resolvedModule.isExternalLibraryImport &&
+        resolvedModule.resolvedFileName.includes(normalizedPkgDir) &&
+        // you can import a .json file if you have resolveJsonModule: true in your tsconfig
+        // but you can't generate declarations for it(which seems fine and good i think?)
+        // and just ignoring imports to them seems fine because from what i can tell
+        // typescript inlines the types for them if the json file import is used in the files exports
+        !resolvedModule.resolvedFileName.endsWith(".json")
+      ) {
+        allDeps.add(resolvedModule.resolvedFileName);
       }
-      return [normalizePath(x), resolvedModule.resolvedFileName];
-    })
-  );
-  let allDeps = new Set<string>(entrypointSourceToTypeScriptSource.values());
-
-  function searchDeps(deps: Set<string>) {
-    for (let dep of deps) {
-      let sourceFile = program!.getSourceFile(dep);
-      if (!sourceFile) {
-        throw new FatalError(
-          `Could not generate type declarations because ${dep} is not in a TypeScript project. Make sure this file is included in your tsconfig.`,
-          pkgName
-        );
-      }
-      let internalDeps = new Set<string>();
-      for (let { text } of (sourceFile as any).imports) {
-        let { resolvedModule } = typescript.resolveModuleName(
-          text,
-          dep,
-          options,
-          typescript.sys,
-          moduleResolutionCache
-        );
-        if (resolvedModule) {
-          if (
-            !allDeps.has(resolvedModule.resolvedFileName) &&
-            !resolvedModule.isExternalLibraryImport &&
-            resolvedModule.resolvedFileName.includes(normalizedDirname) &&
-            // you can import a .json file if you have resolveJsonModule: true in your tsconfig
-            // but you can't generate declarations for it(which seems fine and good i think?)
-            // and just ignoring imports to them seems fine because from what i can tell
-            // typescript inlines the types for them if the json file import is used in the files exports
-            !resolvedModule.resolvedFileName.endsWith(".json")
-          ) {
-            internalDeps.add(resolvedModule.resolvedFileName);
-            allDeps.add(resolvedModule.resolvedFileName);
-          }
-        }
-      }
-      searchDeps(internalDeps);
     }
   }
-  searchDeps(new Set(entrypointSourceToTypeScriptSource.values()));
 
   const diagnosticsHost = getDiagnosticsHost(typescript, projectDir);
 
-  return {
-    entrypointSourceToTypeScriptSource,
-    declarations: await Promise.all(
-      [...allDeps].map((filename) => {
-        return getDeclarationsForFile(
-          filename,
-          typescript,
-          program,
-          normalizedDirname,
-          projectDir,
-          diagnosticsHost
-        );
-      })
-    ),
-  };
+  return Promise.all(
+    [...allDeps].map((filename) => {
+      return getDeclarationsForFile(
+        filename,
+        typescript,
+        program,
+        normalizedPkgDir,
+        projectDir,
+        diagnosticsHost
+      );
+    })
+  );
 }

--- a/packages/cli/src/rollup-plugins/typescript-declarations/get-used-declarations.ts
+++ b/packages/cli/src/rollup-plugins/typescript-declarations/get-used-declarations.ts
@@ -1,0 +1,96 @@
+import {
+  EmittedDeclarationOutput,
+  getDeclarationsForFile,
+  getDiagnosticsHost,
+  TS,
+} from "./common";
+import { Program, ResolvedModuleFull } from "typescript";
+
+export async function getUsedDeclarations(
+  typescript: TS,
+  program: Program,
+  normalizedPkgDir: string,
+  projectDir: string,
+  resolveModuleName: (
+    moduleName: string,
+    containingFile: string
+  ) => ResolvedModuleFull | undefined,
+  resolvedEntrypointSources: string[]
+): Promise<EmittedDeclarationOutput[]> {
+  const depQueue = new Set(resolvedEntrypointSources);
+  const diagnosticsHost = getDiagnosticsHost(typescript, projectDir);
+
+  const emitted: EmittedDeclarationOutput[] = [];
+
+  for (const filename of depQueue) {
+    const imports = new Set<string>();
+    // this is mostly sync except for one bit so running this concurrently wouldn't really help
+    const output = await getDeclarationsForFile(
+      filename,
+      typescript,
+      program,
+      normalizedPkgDir,
+      projectDir,
+      diagnosticsHost,
+      {
+        afterDeclarations: [
+          () => (node) => {
+            // typescript has a exportedModulesFromDeclarationEmit property
+            // on these source files, it's marked @internal though so i'm not using it
+            // might want to detect at runtime if it exists and use it in that case otherwise defer to this
+            // i'm not terribly worried though
+            // you should not have massive declarations files in the way that having massive source
+            // files is actually reasonable
+            if (typescript.isSourceFile(node)) {
+              function handler(node: import("typescript").Node): void {
+                // import/export { x } from "x"
+                if (
+                  (typescript.isImportDeclaration(node) ||
+                    typescript.isExportDeclaration(node)) &&
+                  node.moduleSpecifier !== undefined &&
+                  typescript.isStringLiteral(node.moduleSpecifier)
+                ) {
+                  imports.add(node.moduleSpecifier.text);
+                  return;
+                }
+                // type x = import('a').Blah
+                if (
+                  typescript.isImportTypeNode(node) &&
+                  typescript.isLiteralTypeNode(node.argument) &&
+                  typescript.isStringLiteral(node.argument.literal)
+                ) {
+                  imports.add(node.argument.literal.text);
+                  return;
+                }
+                // import x = require("x")
+                if (
+                  typescript.isExternalModuleReference(node) &&
+                  typescript.isStringLiteral(node.expression)
+                ) {
+                  imports.add(node.expression.text);
+                  return;
+                }
+                typescript.forEachChild(node, handler);
+              }
+              handler(node);
+              return node;
+            }
+            return node;
+          },
+        ],
+      }
+    );
+    emitted.push(output);
+    for (const imported of imports) {
+      const resolvedModule = resolveModuleName(imported, filename);
+      if (
+        resolvedModule &&
+        !resolvedModule.isExternalLibraryImport &&
+        resolvedModule.resolvedFileName.includes(normalizedPkgDir)
+      ) {
+        depQueue.add(resolvedModule.resolvedFileName);
+      }
+    }
+  }
+  return emitted;
+}

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -131,6 +131,7 @@ export const FORMER_FLAGS_THAT_ARE_ENABLED_NOW = new Set<string>([
 export const EXPERIMENTAL_FLAGS = new Set([
   "logCompiledFiles",
   "keepDynamicImportAsDynamicImportInCommonJS",
+  "onlyEmitUsedTypeScriptDeclarations",
 ]);
 
 export function validateProject(project: Project, log = false) {


### PR DESCRIPTION
This should be quite safe but I'm gonna keep it behind an experimental flag for now. It'll be required to be enabled when using the imports conditions stuff.