### PR TITLE
Unify how module specifiers are visited by different declaration transformers

### DIFF
--- a/.changeset/six-carrots-perform.md
+++ b/.changeset/six-carrots-perform.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Fix types like `import('#foo').Foo<import('#bar').Bar>` not replacing the import to `#bar` in generated declarations under the `importsConditions` experimental flag


### PR DESCRIPTION
Just a refactor PR, in preparation for the logic that will fix the issue with explicit `.ts` extensions (the one that we've discussed)