### PR TITLE
Fix referencing a type from another package in the same preconstruct build that has a `.d.ts` file at the entrypoint

### DIFF
--- a/.changeset/gentle-zoos-tickle.md
+++ b/.changeset/gentle-zoos-tickle.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+Fix referencing a type from another package in the same preconstruct build that has a `.d.ts` file at the entrypoint

--- a/packages/cli/src/build/utils.ts
+++ b/packages/cli/src/build/utils.ts
@@ -1,6 +1,10 @@
 import { Project } from "../project";
 import { isTsPath } from "../rollup-plugins/typescript-declarations";
-import { entrypointHasDefaultExport, writeDevTSFiles } from "../dev";
+import {
+  entrypointHasDefaultExport,
+  hasDtsFile,
+  writeDevTSFiles,
+} from "../dev";
 import * as fs from "fs-extra";
 import path from "path";
 
@@ -27,7 +31,7 @@ export async function cleanProjectBeforeBuild(project: Project) {
 
       await Promise.all(
         pkg.entrypoints.map(async (entrypoint) => {
-          if (isTsPath(entrypoint.source)) {
+          if (isTsPath(entrypoint.source) || (await hasDtsFile(entrypoint))) {
             if (!isTypeModule) {
               await fs.mkdir(path.join(entrypoint.directory, "dist"));
             }

--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -26,7 +26,7 @@ import { validateProject } from "./validate";
 
 let tsExtensionPattern = /\.tsx?$/;
 
-async function hasDtsFile(entrypoint: Entrypoint) {
+export async function hasDtsFile(entrypoint: Entrypoint) {
   try {
     const filename = entrypoint.source.replace(/\.jsx?/, ".d.ts");
     await fs.stat(filename);


### PR DESCRIPTION
This will fix https://github.com/emotion-js/emotion/issues/3259