### PR TITLE
Enforce that the main/module/browser/umd:main fields are not present when using the "type": "module" mode

### DIFF
--- a/.changeset/young-ligers-flow.md
+++ b/.changeset/young-ligers-flow.md
@@ -1,0 +1,5 @@
+---
+"@preconstruct/cli": patch
+---
+
+`preconstruct fix`/`preconstruct validate` will now enforce that the `main`/`module`/`browser`/`umd:main` fields are not present when using the experimental `typeModule` flag and the package has `"type": "module"`.

--- a/packages/cli/src/fix.ts
+++ b/packages/cli/src/fix.ts
@@ -44,7 +44,13 @@ async function fixPackage(pkg: Package): Promise<() => Promise<boolean>> {
     }
   }
 
-  if (!pkg.isTypeModule()) {
+  if (pkg.isTypeModule()) {
+    keys(fields).forEach((field) => {
+      if (fields[field]) {
+        delete (pkg.json as any)[field];
+      }
+    });
+  } else {
     keys(fields)
       .filter((x) => fields[x])
       .forEach((field) => {

--- a/packages/cli/src/validate-package.ts
+++ b/packages/cli/src/validate-package.ts
@@ -57,6 +57,14 @@ export function validatePackage(pkg: Package) {
   }
 
   if (pkg.isTypeModule()) {
+    keys(fields).forEach((field) => {
+      if (fields[field]) {
+        throw new FixableError(
+          `"type": "module" packages should not use the "${field}" field.`,
+          pkg.name
+        );
+      }
+    });
     return;
   }
 


### PR DESCRIPTION
Ref https://github.com/changesets/changesets/pull/1482#discussion_r1966853781